### PR TITLE
Add OpenAPI/Roaster REST API for eXide backend

### DIFF
--- a/controller.xq
+++ b/controller.xq
@@ -105,6 +105,14 @@ else if ($local:method = 'get' and $exist:resource = "backdrop.svg") then
         </forward>
     </dispatch>
 
+(: REST API — all /api/* requests are handled by Roaster.
+ : Placed before the unauthorized check so that Roaster can handle
+ : its own auth via OpenAPI security schemes and x-constraints. :)
+else if (starts-with($exist:path, "/api/")) then
+    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+        <forward url="{$exist:controller}/modules/api/router.xq"/>
+    </dispatch>
+
 (: handle unauthorized request :)
 
 else if (not($user-allowed))

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -2,4 +2,5 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/eXide" abbrev="eXide" version="{{version}}" spec="1.0">
     <title>eXide - XQuery IDE</title>
     <dependency processor="http://exist-db.org" semver-min="6.1.0"/>
+    <dependency package="http://e-editiones.org/roaster" semver-min="1.8.0"/>
 </package>

--- a/modules/api.json
+++ b/modules/api.json
@@ -1,0 +1,1413 @@
+{
+    "openapi": "3.0.4",
+    "info": {
+        "version": "1.0.0",
+        "title": "eXide API",
+        "description": "REST API for eXide, the web-based XQuery IDE for eXist-db."
+    },
+    "servers": [
+        {
+            "url": "/exist/apps/eXide",
+            "description": "eXide application context"
+        }
+    ],
+    "security": [
+        {
+            "cookieAuth": []
+        },
+        {
+            "basicAuth": []
+        }
+    ],
+    "components": {
+        "securitySchemes": {
+            "basicAuth": {
+                "type": "http",
+                "scheme": "basic"
+            },
+            "cookieAuth": {
+                "type": "apiKey",
+                "name": "org.exist.login",
+                "in": "cookie"
+            }
+        }
+    },
+    "paths": {
+        "/api/auth/session": {
+            "post": {
+                "summary": "Login and create session",
+                "operationId": "auth:login",
+                "tags": [
+                    "auth"
+                ],
+                "security": [],
+                "responses": {
+                    "200": {
+                        "description": "Login successful",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid credentials",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Logout and destroy session",
+                "operationId": "auth:logout",
+                "tags": [
+                    "auth"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Logged out",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/whoami": {
+            "get": {
+                "summary": "Current user info and permissions",
+                "operationId": "auth:whoami",
+                "tags": [
+                    "auth"
+                ],
+                "security": [],
+                "responses": {
+                    "200": {
+                        "description": "User info",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/db/{path}": {
+            "get": {
+                "summary": "Browse collection or load document",
+                "operationId": "db:get",
+                "tags": [
+                    "db"
+                ],
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "start",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "default": 50
+                        }
+                    },
+                    {
+                        "name": "filter",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "download",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Collection listing or document content",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "summary": "Create or update a document",
+                "operationId": "db:put",
+                "tags": [
+                    "db"
+                ],
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "*/*": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Document stored",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create subcollection or batch operations (copy, move, rename)",
+                "operationId": "db:post",
+                "tags": [
+                    "db"
+                ],
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Operation completed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete resource or collection",
+                "operationId": "db:delete",
+                "tags": [
+                    "db"
+                ],
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Modify permissions, owner, group, or MIME type",
+                "operationId": "db:patch",
+                "tags": [
+                    "db"
+                ],
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Metadata updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/query": {
+            "post": {
+                "summary": "Execute XQuery",
+                "operationId": "query:execute",
+                "tags": [
+                    "query"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "query"
+                                ],
+                                "properties": {
+                                    "query": {
+                                        "type": "string"
+                                    },
+                                    "base": {
+                                        "type": "string"
+                                    },
+                                    "serialization": {
+                                        "type": "string",
+                                        "default": "adaptive"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Query results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Query execution not allowed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/query/compile": {
+            "post": {
+                "summary": "Compile-check XQuery without executing",
+                "operationId": "query:compile",
+                "tags": [
+                    "query"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "query"
+                                ],
+                                "properties": {
+                                    "query": {
+                                        "type": "string"
+                                    },
+                                    "base": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Compilation result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/query/{id}/results": {
+            "get": {
+                "summary": "Retrieve paginated query results",
+                "operationId": "query:results",
+                "tags": [
+                    "query"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "start",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result items",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Session expired or invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/editor/completions": {
+            "get": {
+                "summary": "Autocomplete: functions, variables, and modules",
+                "operationId": "editor:completions",
+                "tags": [
+                    "editor"
+                ],
+                "parameters": [
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "signature",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "base",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "source",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "uri",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "mprefix",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Completion candidates",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/editor/symbols": {
+            "get": {
+                "summary": "Document outline and symbol list for imported modules",
+                "operationId": "editor:symbols",
+                "tags": [
+                    "editor"
+                ],
+                "parameters": [
+                    {
+                        "name": "uri",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "source",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "base",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Symbol list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/editor/modules": {
+            "get": {
+                "summary": "Discover available XQuery modules",
+                "operationId": "editor:modules",
+                "tags": [
+                    "editor"
+                ],
+                "parameters": [
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Module list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/editor/validate": {
+            "post": {
+                "summary": "Validate XML against schema catalog",
+                "operationId": "editor:validate",
+                "tags": [
+                    "editor"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/xml": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        },
+                        "text/xml": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "validate",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Validation result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/editor/imports": {
+            "get": {
+                "summary": "Discover importable modules (package-local and global)",
+                "operationId": "editor:imports",
+                "tags": [
+                    "editor"
+                ],
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "query",
+                        "description": "Path of the file being edited (to determine package context)",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "description": "Filter by namespace prefix",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "uri",
+                        "in": "query",
+                        "description": "Already-imported namespace URIs to exclude",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Available modules for import",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/editor/docs/{name}": {
+            "get": {
+                "summary": "Function documentation by name#arity",
+                "operationId": "editor:docs",
+                "tags": [
+                    "editor"
+                ],
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Function documentation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Function not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/templates": {
+            "get": {
+                "summary": "Template catalog grouped by language",
+                "operationId": "templates:list",
+                "tags": [
+                    "templates"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Template catalog",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/templates/{name}": {
+            "get": {
+                "summary": "Retrieve template source code",
+                "operationId": "templates:get",
+                "tags": [
+                    "templates"
+                ],
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Template source",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/packages": {
+            "get": {
+                "summary": "List installed packages (apps and libraries)",
+                "operationId": "packages:list",
+                "tags": [
+                    "packages"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Package list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Install .xar package or create new app from template",
+                "operationId": "packages:install",
+                "tags": [
+                    "packages"
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                }
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "abbrev": {
+                                        "type": "string"
+                                    },
+                                    "template": {
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Package installed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid package",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/packages/{abbrev}": {
+            "get": {
+                "summary": "Package descriptor and metadata",
+                "operationId": "packages:get",
+                "tags": [
+                    "packages"
+                ],
+                "parameters": [
+                    {
+                        "name": "abbrev",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Package info",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Package not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Uninstall package",
+                "operationId": "packages:uninstall",
+                "tags": [
+                    "packages"
+                ],
+                "parameters": [
+                    {
+                        "name": "abbrev",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Package uninstalled",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/packages/{abbrev}/build": {
+            "post": {
+                "summary": "Build .xar from source collection",
+                "operationId": "packages:build",
+                "tags": [
+                    "packages"
+                ],
+                "parameters": [
+                    {
+                        "name": "abbrev",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "XAR binary",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/packages/{abbrev}/deploy": {
+            "post": {
+                "summary": "Deploy package to target collection",
+                "operationId": "packages:deploy",
+                "tags": [
+                    "packages"
+                ],
+                "parameters": [
+                    {
+                        "name": "abbrev",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "target": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Package deployed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/packages/{abbrev}/config": {
+            "post": {
+                "summary": "Apply collection.xconf and trigger reindex",
+                "operationId": "packages:config",
+                "tags": [
+                    "packages"
+                ],
+                "x-constraints": {
+                    "groups": [
+                        "dba"
+                    ]
+                },
+                "parameters": [
+                    {
+                        "name": "abbrev",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "config"
+                                ],
+                                "properties": {
+                                    "collection": {
+                                        "type": "string"
+                                    },
+                                    "config": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Config applied",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/search": {
+            "post": {
+                "summary": "Full-text search across database resources",
+                "operationId": "search:search",
+                "tags": [
+                    "search"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "query"
+                                ],
+                                "properties": {
+                                    "query": {
+                                        "type": "string"
+                                    },
+                                    "collection": {
+                                        "type": "string",
+                                        "default": "/db"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "default": "all"
+                                    },
+                                    "regex": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "caseSensitive": {
+                                        "type": "boolean",
+                                        "default": false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/status": {
+            "get": {
+                "summary": "Server health and JMX metrics",
+                "operationId": "admin:status",
+                "tags": [
+                    "admin"
+                ],
+                "x-constraints": {
+                    "groups": [
+                        "dba"
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "Server status",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/queries": {
+            "get": {
+                "summary": "Running and recent queries",
+                "operationId": "admin:queries",
+                "tags": [
+                    "admin"
+                ],
+                "x-constraints": {
+                    "groups": [
+                        "dba"
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "Query list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/queries/{id}": {
+            "delete": {
+                "summary": "Kill a running query",
+                "operationId": "admin:kill-query",
+                "tags": [
+                    "admin"
+                ],
+                "x-constraints": {
+                    "groups": [
+                        "dba"
+                    ]
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Query killed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/test": {
+            "post": {
+                "summary": "Run XQSuite tests on a module",
+                "operationId": "test:run",
+                "tags": [
+                    "test"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "source"
+                                ],
+                                "properties": {
+                                    "source": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Test results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/sync": {
+            "post": {
+                "summary": "Synchronize filesystem directory with database collection",
+                "operationId": "sync:sync",
+                "tags": [
+                    "sync"
+                ],
+                "x-constraints": {
+                    "groups": [
+                        "dba"
+                    ]
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "collection"
+                                ],
+                                "properties": {
+                                    "collection": {
+                                        "type": "string"
+                                    },
+                                    "dir": {
+                                        "type": "string"
+                                    },
+                                    "after": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Sync results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/api.json
+++ b/modules/api.json
@@ -106,7 +106,7 @@
                 }
             }
         },
-        "/api/db/{path}": {
+        "/api/storage/{path}": {
             "get": {
                 "summary": "Browse collection or load document",
                 "operationId": "db:get",
@@ -988,6 +988,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "name": "collection",
+                        "in": "query",
+                        "description": "Resolve package by collection path instead of abbrev (use _ as abbrev placeholder)",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {
@@ -1246,6 +1254,27 @@
                 "responses": {
                     "200": {
                         "description": "Server status",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/accounts": {
+            "get": {
+                "summary": "List users and groups",
+                "operationId": "admin:accounts",
+                "tags": [
+                    "admin"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Users and groups",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/modules/api/admin.xqm
+++ b/modules/api/admin.xqm
@@ -50,6 +50,23 @@ declare function admin:queries($request as map(*)) {
 };
 
 (:~
+ : GET /api/admin/accounts — List users and groups (for permissions dialogs).
+ :)
+declare function admin:accounts($request as map(*)) {
+    map {
+        "users": array {
+            distinct-values(
+                for $group in sm:list-groups()
+                return
+                    try { sm:get-group-members($group) }
+                    catch * { () }
+            )
+        },
+        "groups": array { sm:list-groups() }
+    }
+};
+
+(:~
  : DELETE /api/admin/queries/{id} — Kill a running query.
  :)
 declare function admin:kill-query($request as map(*)) {

--- a/modules/api/admin.xqm
+++ b/modules/api/admin.xqm
@@ -1,0 +1,65 @@
+(:
+ :  eXide REST API — Admin and monitoring handlers.
+ :  Migrated from monitor.xq.
+ :)
+xquery version "3.1";
+
+module namespace admin="http://exist-db.org/apps/eXide/api/admin";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+
+(:~
+ : GET /api/admin/status — Server health and JMX metrics.
+ :)
+declare function admin:status($request as map(*)) {
+    let $jmx :=
+        try { system:get-running-xqueries() } catch * { () }
+    let $token :=
+        try {
+            let $raw := file:read(system:get-exist-home() || "/data/jmxservlet.token")
+            let $line := tokenize($raw, "\n")[starts-with(., "token=")]
+            return substring-after($line, "token=")
+        } catch * { () }
+    return map {
+        "version": system:get-version(),
+        "revision": system:get-revision(),
+        "build": system:get-build(),
+        "uptime": system:get-uptime(),
+        "jmxToken": ($token, "")[1],
+        "runningQueries": count($jmx//system:query)
+    }
+};
+
+(:~
+ : GET /api/admin/queries — Running and recent queries.
+ :)
+declare function admin:queries($request as map(*)) {
+    let $running := system:get-running-xqueries()
+    return map {
+        "queries": array {
+            for $query in $running//system:query
+            return map {
+                "id": $query/@id/string(),
+                "sourceType": $query/@sourceType/string(),
+                "started": $query/@started/string(),
+                "terminating": string($query/@terminating),
+                "sourceKey": $query/system:sourceKey/string()
+            }
+        }
+    }
+};
+
+(:~
+ : DELETE /api/admin/queries/{id} — Kill a running query.
+ :)
+declare function admin:kill-query($request as map(*)) {
+    let $id := $request?parameters?id
+    return
+        try {
+            let $_ := system:kill-running-xquery(xs:integer($id))
+            return map { "status": "ok" }
+        } catch * {
+            roaster:response(400, "application/json",
+                map { "error": $err:description })
+        }
+};

--- a/modules/api/auth.xqm
+++ b/modules/api/auth.xqm
@@ -1,0 +1,67 @@
+(:
+ :  eXide REST API — Authentication handlers.
+ :)
+xquery version "3.1";
+
+module namespace auth="http://exist-db.org/apps/eXide/api/auth";
+
+import module namespace login="http://exist-db.org/xquery/login"
+    at "resource:org/exist/xquery/modules/persistentlogin/login.xql";
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace config="http://exist-db.org/xquery/apps/config" at "../config.xqm";
+
+declare variable $auth:LOGIN_DOMAIN := "org.exist.login";
+
+declare function auth:get-user() as xs:string? {
+    let $_ := login:set-user($auth:LOGIN_DOMAIN, "P7D", false())
+    return request:get-attribute($auth:LOGIN_DOMAIN || ".user")
+};
+
+declare function auth:is-allowed($user as xs:string?) as xs:boolean {
+    let $conf := config:get-configuration()
+    return
+        $conf/restrictions/@guest = "yes" or (
+            exists($user) and not($user = ("guest", "nobody"))
+        )
+};
+
+(:~
+ : POST /api/auth/session — Login.
+ :)
+declare function auth:login($request as map(*)) {
+    let $user := auth:get-user()
+    return
+        if (auth:is-allowed($user)) then
+            map {
+                "user": ($user, "guest")[1],
+                "isAdmin": sm:is-dba(($user, "guest")[1])
+            }
+        else
+            roaster:response(401, "application/json",
+                map { "error": "unauthorized" })
+};
+
+(:~
+ : DELETE /api/auth/session — Logout.
+ :)
+declare function auth:logout($request as map(*)) {
+    let $_ := session:invalidate()
+    return map { "status": "ok" }
+};
+
+(:~
+ : GET /api/auth/whoami — Current user info.
+ :)
+declare function auth:whoami($request as map(*)) {
+    let $user := auth:get-user()
+    let $conf := config:get-configuration()
+    let $user-to-check := ($user, "guest")[1]
+    return map {
+        "user": $user-to-check,
+        "isAdmin": sm:is-dba($user-to-check),
+        "isLoggedIn": exists($user) and not($user = ("guest", "nobody")),
+        "queryExecution": sm:is-dba($user-to-check) or (
+            $conf/restrictions/@execute-query = "yes" and auth:is-allowed($user)
+        )
+    }
+};

--- a/modules/api/db.xqm
+++ b/modules/api/db.xqm
@@ -12,11 +12,27 @@ import module namespace config="http://exist-db.org/xquery/apps/config" at "../c
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 
+(: Handle difference between 4.x.x and 5.x.x releases of eXist :)
+declare variable $db:copy-collection :=
+    let $fnNew := function-lookup(xs:QName("xmldb:copy-collection"), 2)
+    return
+        if (exists($fnNew)) then $fnNew else function-lookup(xs:QName("xmldb:copy"), 2);
+
+declare variable $db:copy-resource :=
+    let $fnNew := function-lookup(xs:QName("xmldb:copy-resource"), 4)
+    return
+        if (exists($fnNew)) then $fnNew
+        else
+            let $fnOld := function-lookup(xs:QName("xmldb:copy"), 3)
+            return function($sourceCol, $sourceName, $targetCol, $targetName) {
+                $fnOld($sourceCol, $targetCol, $sourceName)
+            };
+
 (:~
- : GET /api/db/{path} — Browse collection or load document.
+ : GET /api/storage/{path} — Browse collection or load document.
  :)
 declare function db:get($request as map(*)) {
-    let $path := "/" || $request?parameters?path
+    let $path := db:encode-path("/" || $request?parameters?path)
     let $user := (request:get-attribute("org.exist.login.user"), "guest")[1]
     return
         if (xmldb:collection-available($path)) then
@@ -29,10 +45,10 @@ declare function db:get($request as map(*)) {
 };
 
 (:~
- : PUT /api/db/{path} — Create or update document.
+ : PUT /api/storage/{path} — Create or update document.
  :)
 declare function db:put($request as map(*)) {
-    let $path := "/" || $request?parameters?path
+    let $path := db:encode-path("/" || $request?parameters?path)
     let $data := $request?body
     let $collection := replace($path, "/[^/]+$", "")
     let $resource := replace($path, "^.*/", "")
@@ -56,11 +72,11 @@ declare function db:put($request as map(*)) {
 };
 
 (:~
- : POST /api/db/{path} — Create subcollection or batch operations.
+ : POST /api/storage/{path} — Create subcollection or batch operations.
  : Body: { "action": "create" | "copy" | "move" | "rename", ... }
  :)
 declare function db:post($request as map(*)) {
-    let $path := "/" || $request?parameters?path
+    let $path := db:encode-path("/" || $request?parameters?path)
     let $body := $request?body
     let $action := $body?action
     return
@@ -78,9 +94,14 @@ declare function db:post($request as map(*)) {
                 try {
                     let $sources := $body?sources?*
                     for $source in $sources
-                    let $name := replace($source, "^.*/", "")
-                    return xmldb:copy-resource(
-                        replace($source, "/[^/]+$", ""), $name, $path, $name)
+                    let $enc-source := db:encode-path($source)
+                    return
+                        if (xmldb:collection-available($enc-source)) then
+                            $db:copy-collection($enc-source, $path)
+                        else
+                            let $name := replace($enc-source, "^.*/", "")
+                            let $src-col := replace($enc-source, "/[^/]+$", "")
+                            return $db:copy-resource($src-col, $name, $path, $name)
                     ,
                     map { "status": "ok" }
                 } catch * {
@@ -91,9 +112,14 @@ declare function db:post($request as map(*)) {
                 try {
                     let $sources := $body?sources?*
                     for $source in $sources
-                    let $name := replace($source, "^.*/", "")
-                    let $src-col := replace($source, "/[^/]+$", "")
-                    return xmldb:move($src-col, $path, $name)
+                    let $enc-source := db:encode-path($source)
+                    return
+                        if (xmldb:collection-available($enc-source)) then
+                            xmldb:move($enc-source, $path)
+                        else
+                            let $name := replace($enc-source, "^.*/", "")
+                            let $src-col := replace($enc-source, "/[^/]+$", "")
+                            return xmldb:move($src-col, $path, $name)
                     ,
                     map { "status": "ok" }
                 } catch * {
@@ -103,12 +129,18 @@ declare function db:post($request as map(*)) {
             case "rename" return
                 try {
                     let $target := $body?target
-                    let $col := replace($path, "/[^/]+$", "")
-                    let $name := replace($path, "^.*/", "")
-                    return (
-                        xmldb:rename($col, $name, $target),
-                        map { "status": "ok" }
-                    )
+                    return
+                        if (xmldb:collection-available($path)) then (
+                            xmldb:rename($path, $target),
+                            map { "status": "ok" }
+                        )
+                        else
+                            let $col := replace($path, "/[^/]+$", "")
+                            let $name := replace($path, "^.*/", "")
+                            return (
+                                xmldb:rename($col, $name, $target),
+                                map { "status": "ok" }
+                            )
                 } catch * {
                     roaster:response(400, "application/json",
                         map { "error": $err:description })
@@ -119,10 +151,10 @@ declare function db:post($request as map(*)) {
 };
 
 (:~
- : DELETE /api/db/{path} — Delete resource or collection.
+ : DELETE /api/storage/{path} — Delete resource or collection.
  :)
 declare function db:delete($request as map(*)) {
-    let $path := "/" || $request?parameters?path
+    let $path := db:encode-path("/" || $request?parameters?path)
     return
         try {
             if (xmldb:collection-available($path)) then (
@@ -143,11 +175,11 @@ declare function db:delete($request as map(*)) {
 };
 
 (:~
- : PATCH /api/db/{path} — Modify permissions, owner, group, MIME type.
+ : PATCH /api/storage/{path} — Modify permissions, owner, group, MIME type.
  : Body: { "owner": "...", "group": "...", "mode": "rwxr-x---", "mime": "..." }
  :)
 declare function db:patch($request as map(*)) {
-    let $path := "/" || $request?parameters?path
+    let $path := db:encode-path("/" || $request?parameters?path)
     let $body := $request?body
     return
         try {
@@ -163,6 +195,20 @@ declare function db:patch($request as map(*)) {
 };
 
 
+(:~
+ : Encode each segment of a path for eXist-db internal use.
+ : Converts /db/AéB → /db/A%C3%A9B while preserving path separators.
+ :)
+declare %private function db:encode-path($path as xs:string) as xs:string {
+    string-join(
+        for $segment in tokenize($path, "/")
+        return
+            if ($segment = "") then ""
+            else xmldb:encode($segment),
+        "/"
+    )
+};
+
 (: ── Internal helpers ─────────────────────────────────────── :)
 
 declare %private function db:browse-collection($path, $request, $user) {
@@ -175,33 +221,47 @@ declare %private function db:browse-collection($path, $request, $user) {
         for $child in $children
         where empty($filter) or contains($child, $filter)
         order by lower-case($child)
-        return map {
-            "name": $child,
-            "isCollection": true(),
-            "path": $path || "/" || $child,
-            "writable": sm:has-access(xs:anyURI($path || "/" || $child), "w")
-        },
+        return
+            let $child-path := $path || "/" || $child
+            let $child-uri := xs:anyURI($child-path)
+            return map {
+                "name": xmldb:decode-uri(xs:anyURI($child)),
+                "isCollection": true(),
+                "path": xmldb:decode-uri(xs:anyURI($child-path)),
+                "writable": sm:has-access($child-uri, "w"),
+                "permissions": sm:get-permissions($child-uri)/sm:permission/string(@mode),
+                "owner": sm:get-permissions($child-uri)/sm:permission/string(@owner),
+                "group": sm:get-permissions($child-uri)/sm:permission/string(@group)
+            },
         for $res in $resources
         where empty($filter) or contains($res, $filter)
         order by lower-case($res)
         return
             let $res-path := $path || "/" || $res
+            let $res-uri := xs:anyURI($res-path)
             return map {
-                "name": $res,
+                "name": xmldb:decode-uri(xs:anyURI($res)),
                 "isCollection": false(),
-                "path": $res-path,
+                "path": xmldb:decode-uri(xs:anyURI($res-path)),
                 "mime": xmldb:get-mime-type($res-path),
-                "writable": sm:has-access(xs:anyURI($res-path), "w"),
-                "lastModified": string(xmldb:last-modified($path, $res))
+                "writable": sm:has-access($res-uri, "w"),
+                "lastModified": string(xmldb:last-modified($path, $res)),
+                "permissions": sm:get-permissions($res-uri)/sm:permission/string(@mode),
+                "owner": sm:get-permissions($res-uri)/sm:permission/string(@owner),
+                "group": sm:get-permissions($res-uri)/sm:permission/string(@group)
             }
     )
     let $total := count($all-items)
+    let $path-uri := xs:anyURI($path)
     return map {
         "path": $path,
         "total": $total,
         "start": $start,
         "count": $count,
-        "writable": sm:has-access(xs:anyURI($path), "w"),
+        "writable": sm:has-access($path-uri, "w"),
+        "permissions": sm:get-permissions($path-uri)/sm:permission/string(@mode),
+        "owner": sm:get-permissions($path-uri)/sm:permission/string(@owner),
+        "group": sm:get-permissions($path-uri)/sm:permission/string(@group),
         "items": array { subsequence($all-items, $start, $count) }
     }
 };
@@ -218,13 +278,17 @@ declare %private function db:load-document($path, $request, $user) {
                 roaster:response(200, $mime, util:binary-doc($path))
             else
                 (: Return metadata for binary docs unless downloading :)
-                map {
+                let $uri := xs:anyURI($path)
+                return map {
                     "path": $path,
                     "mime": $mime,
                     "binary": true(),
                     "size": xmldb:size(replace($path, "/[^/]+$", ""), replace($path, "^.*/", "")),
                     "lastModified": string(xmldb:last-modified(
-                        replace($path, "/[^/]+$", ""), replace($path, "^.*/", "")))
+                        replace($path, "/[^/]+$", ""), replace($path, "^.*/", ""))),
+                    "permissions": sm:get-permissions($uri)/sm:permission/string(@mode),
+                    "owner": sm:get-permissions($uri)/sm:permission/string(@owner),
+                    "group": sm:get-permissions($uri)/sm:permission/string(@group)
                 }
         else
             let $content := serialize(doc($path), <output:serialization-parameters>
@@ -236,12 +300,16 @@ declare %private function db:load-document($path, $request, $user) {
                 if ($download) then
                     roaster:response(200, $mime, $content)
                 else
-                    map {
+                    let $uri := xs:anyURI($path)
+                    return map {
                         "path": $path,
                         "mime": $mime,
                         "binary": false(),
                         "content": $content,
                         "lastModified": string(xmldb:last-modified(
-                            replace($path, "/[^/]+$", ""), replace($path, "^.*/", "")))
+                            replace($path, "/[^/]+$", ""), replace($path, "^.*/", ""))),
+                        "permissions": sm:get-permissions($uri)/sm:permission/string(@mode),
+                        "owner": sm:get-permissions($uri)/sm:permission/string(@owner),
+                        "group": sm:get-permissions($uri)/sm:permission/string(@group)
                     }
 };

--- a/modules/api/db.xqm
+++ b/modules/api/db.xqm
@@ -54,7 +54,7 @@ declare function db:put($request as map(*)) {
     let $resource := replace($path, "^.*/", "")
     return
         try {
-            let $stored := xmldb:store($collection, $resource, $data)
+            let $stored := xs:anyURI(xmldb:store($collection, $resource, $data))
             (: Fix permissions for XQuery files :)
             let $mime := xmldb:get-mime-type($stored)
             let $_ :=

--- a/modules/api/db.xqm
+++ b/modules/api/db.xqm
@@ -1,0 +1,247 @@
+(:
+ :  eXide REST API — Database resource handlers.
+ :  Migrated from collections.xq, load.xq, store.xq.
+ :)
+xquery version "3.1";
+
+module namespace db="http://exist-db.org/apps/eXide/api/db";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace dbutil="http://exist-db.org/xquery/dbutil" at "../dbutils.xqm";
+import module namespace config="http://exist-db.org/xquery/apps/config" at "../config.xqm";
+
+declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+
+(:~
+ : GET /api/db/{path} — Browse collection or load document.
+ :)
+declare function db:get($request as map(*)) {
+    let $path := "/" || $request?parameters?path
+    let $user := (request:get-attribute("org.exist.login.user"), "guest")[1]
+    return
+        if (xmldb:collection-available($path)) then
+            db:browse-collection($path, $request, $user)
+        else if (doc-available($path) or util:binary-doc-available($path)) then
+            db:load-document($path, $request, $user)
+        else
+            roaster:response(404, "application/json",
+                map { "error": "Not found: " || $path })
+};
+
+(:~
+ : PUT /api/db/{path} — Create or update document.
+ :)
+declare function db:put($request as map(*)) {
+    let $path := "/" || $request?parameters?path
+    let $data := $request?body
+    let $collection := replace($path, "/[^/]+$", "")
+    let $resource := replace($path, "^.*/", "")
+    return
+        try {
+            let $stored := xmldb:store($collection, $resource, $data)
+            (: Fix permissions for XQuery files :)
+            let $mime := xmldb:get-mime-type($stored)
+            let $_ :=
+                if ($mime = "application/xquery") then
+                    sm:chmod($stored, "rwxr-xr-x")
+                else ()
+            return map {
+                "status": "ok",
+                "path": $stored
+            }
+        } catch * {
+            roaster:response(400, "application/json",
+                map { "error": $err:description })
+        }
+};
+
+(:~
+ : POST /api/db/{path} — Create subcollection or batch operations.
+ : Body: { "action": "create" | "copy" | "move" | "rename", ... }
+ :)
+declare function db:post($request as map(*)) {
+    let $path := "/" || $request?parameters?path
+    let $body := $request?body
+    let $action := $body?action
+    return
+        switch ($action)
+            case "create" return
+                try {
+                    let $name := $body?name
+                    let $created := xmldb:create-collection($path, $name)
+                    return map { "status": "ok", "path": $created }
+                } catch * {
+                    roaster:response(400, "application/json",
+                        map { "error": $err:description })
+                }
+            case "copy" return
+                try {
+                    let $sources := $body?sources?*
+                    for $source in $sources
+                    let $name := replace($source, "^.*/", "")
+                    return xmldb:copy-resource(
+                        replace($source, "/[^/]+$", ""), $name, $path, $name)
+                    ,
+                    map { "status": "ok" }
+                } catch * {
+                    roaster:response(400, "application/json",
+                        map { "error": $err:description })
+                }
+            case "move" return
+                try {
+                    let $sources := $body?sources?*
+                    for $source in $sources
+                    let $name := replace($source, "^.*/", "")
+                    let $src-col := replace($source, "/[^/]+$", "")
+                    return xmldb:move($src-col, $path, $name)
+                    ,
+                    map { "status": "ok" }
+                } catch * {
+                    roaster:response(400, "application/json",
+                        map { "error": $err:description })
+                }
+            case "rename" return
+                try {
+                    let $target := $body?target
+                    let $col := replace($path, "/[^/]+$", "")
+                    let $name := replace($path, "^.*/", "")
+                    return (
+                        xmldb:rename($col, $name, $target),
+                        map { "status": "ok" }
+                    )
+                } catch * {
+                    roaster:response(400, "application/json",
+                        map { "error": $err:description })
+                }
+            default return
+                roaster:response(400, "application/json",
+                    map { "error": "Unknown action: " || $action })
+};
+
+(:~
+ : DELETE /api/db/{path} — Delete resource or collection.
+ :)
+declare function db:delete($request as map(*)) {
+    let $path := "/" || $request?parameters?path
+    return
+        try {
+            if (xmldb:collection-available($path)) then (
+                xmldb:remove($path),
+                map { "status": "ok" }
+            )
+            else
+                let $col := replace($path, "/[^/]+$", "")
+                let $name := replace($path, "^.*/", "")
+                return (
+                    xmldb:remove($col, $name),
+                    map { "status": "ok" }
+                )
+        } catch * {
+            roaster:response(400, "application/json",
+                map { "error": $err:description })
+        }
+};
+
+(:~
+ : PATCH /api/db/{path} — Modify permissions, owner, group, MIME type.
+ : Body: { "owner": "...", "group": "...", "mode": "rwxr-x---", "mime": "..." }
+ :)
+declare function db:patch($request as map(*)) {
+    let $path := "/" || $request?parameters?path
+    let $body := $request?body
+    return
+        try {
+            if (exists($body?owner)) then sm:chown($path, $body?owner) else (),
+            if (exists($body?group)) then sm:chgrp($path, $body?group) else (),
+            if (exists($body?mode)) then sm:chmod($path, $body?mode) else (),
+            if (exists($body?mime)) then xmldb:set-mime-type($path, $body?mime) else (),
+            map { "status": "ok" }
+        } catch * {
+            roaster:response(403, "application/json",
+                map { "error": $err:description })
+        }
+};
+
+
+(: ── Internal helpers ─────────────────────────────────────── :)
+
+declare %private function db:browse-collection($path, $request, $user) {
+    let $start := ($request?parameters?start, 1)[1]
+    let $count := ($request?parameters?count, 50)[1]
+    let $filter := $request?parameters?filter
+    let $children := xmldb:get-child-collections($path)
+    let $resources := xmldb:get-child-resources($path)
+    let $all-items := (
+        for $child in $children
+        where empty($filter) or contains($child, $filter)
+        order by lower-case($child)
+        return map {
+            "name": $child,
+            "isCollection": true(),
+            "path": $path || "/" || $child,
+            "writable": sm:has-access(xs:anyURI($path || "/" || $child), "w")
+        },
+        for $res in $resources
+        where empty($filter) or contains($res, $filter)
+        order by lower-case($res)
+        return
+            let $res-path := $path || "/" || $res
+            return map {
+                "name": $res,
+                "isCollection": false(),
+                "path": $res-path,
+                "mime": xmldb:get-mime-type($res-path),
+                "writable": sm:has-access(xs:anyURI($res-path), "w"),
+                "lastModified": string(xmldb:last-modified($path, $res))
+            }
+    )
+    let $total := count($all-items)
+    return map {
+        "path": $path,
+        "total": $total,
+        "start": $start,
+        "count": $count,
+        "writable": sm:has-access(xs:anyURI($path), "w"),
+        "items": array { subsequence($all-items, $start, $count) }
+    }
+};
+
+declare %private function db:load-document($path, $request, $user) {
+    let $download := ($request?parameters?download, false())[1]
+    let $mime := xmldb:get-mime-type($path)
+    return
+        if (not(sm:has-access(xs:anyURI($path), "r"))) then
+            roaster:response(404, "application/json",
+                map { "error": "Not found or no read access" })
+        else if (util:binary-doc-available($path)) then
+            if ($download) then
+                roaster:response(200, $mime, util:binary-doc($path))
+            else
+                (: Return metadata for binary docs unless downloading :)
+                map {
+                    "path": $path,
+                    "mime": $mime,
+                    "binary": true(),
+                    "size": xmldb:size(replace($path, "/[^/]+$", ""), replace($path, "^.*/", "")),
+                    "lastModified": string(xmldb:last-modified(
+                        replace($path, "/[^/]+$", ""), replace($path, "^.*/", "")))
+                }
+        else
+            let $content := serialize(doc($path), <output:serialization-parameters>
+                <output:method>xml</output:method>
+                <output:indent>yes</output:indent>
+                <output:omit-xml-declaration>yes</output:omit-xml-declaration>
+            </output:serialization-parameters>)
+            return
+                if ($download) then
+                    roaster:response(200, $mime, $content)
+                else
+                    map {
+                        "path": $path,
+                        "mime": $mime,
+                        "binary": false(),
+                        "content": $content,
+                        "lastModified": string(xmldb:last-modified(
+                            replace($path, "/[^/]+$", ""), replace($path, "^.*/", "")))
+                    }
+};

--- a/modules/api/editor.xqm
+++ b/modules/api/editor.xqm
@@ -1,0 +1,403 @@
+(:
+ :  eXide REST API — Editor intelligence handlers.
+ :  Migrated from funcdoc.xq, find.xq, outline.xq, validate-xml.xq.
+ :)
+xquery version "3.1";
+
+module namespace editor="http://exist-db.org/apps/eXide/api/editor";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace dbutil="http://exist-db.org/xquery/dbutil" at "../dbutils.xqm";
+
+declare namespace expath="http://expath.org/ns/pkg";
+
+(:~
+ : GET /api/editor/completions — Autocomplete for functions, variables, modules.
+ : Migrated from funcdoc.xq.
+ :)
+declare function editor:completions($request as map(*)) {
+    let $q := $request?parameters?prefix
+    let $signature := $request?parameters?signature
+    let $base := $request?parameters?base
+    let $sources := $request?parameters?source
+    let $uris := $request?parameters?uri
+    let $mprefixes := $request?parameters?mprefix
+
+    let $sources := if ($sources instance of xs:string) then $sources else if (exists($sources)) then $sources?* else ()
+    let $uris := if ($uris instance of xs:string) then $uris else if (exists($uris)) then $uris?* else ()
+    let $mprefixes := if ($mprefixes instance of xs:string) then $mprefixes else if (exists($mprefixes)) then $mprefixes?* else ()
+
+    return array {
+        if ($q) then editor:get-built-in-functions($q) else (),
+        if ($signature) then
+            let $desc := editor:get-by-signature($signature)
+            return
+                if (exists($desc)) then $desc
+                else editor:get-imported-functions($q, $signature, $base, $sources, $uris, $mprefixes)
+        else
+            editor:get-imported-functions($q, $signature, $base, $sources, $uris, $mprefixes)
+    }
+};
+
+(:~
+ : GET /api/editor/symbols — Document outline for imported modules.
+ : Migrated from outline.xq.
+ :)
+declare function editor:symbols($request as map(*)) {
+    let $uris := $request?parameters?uri
+    let $sources := $request?parameters?source
+    let $prefixes := $request?parameters?prefix
+    let $bases := $request?parameters?base
+
+    let $uris := if ($uris instance of xs:string) then $uris else if (exists($uris)) then $uris?* else ()
+    let $sources := if ($sources instance of xs:string) then $sources else if (exists($sources)) then $sources?* else ()
+    let $prefixes := if ($prefixes instance of xs:string) then $prefixes else if (exists($prefixes)) then $prefixes?* else ()
+    let $bases := if ($bases instance of xs:string) then $bases else if (exists($bases)) then $bases?* else ()
+
+    return array {
+        for $uri at $i in $uris
+        let $source := $sources[$i]
+        let $prefix := $prefixes[$i]
+        let $base := $bases[$i]
+        let $module-source :=
+            if (matches($source, "^(/|\w+:)")) then $source
+            else if (exists($base)) then concat($base, "/", $source)
+            else $source
+        return
+            try {
+                let $module := inspect:inspect-module($module-source)
+                return map {
+                    "source": $module-source,
+                    "prefix": $prefix,
+                    "functions": array {
+                        for $fn in $module/function[not(annotation/@name = "private")]
+                        let $name := if (contains($fn/@name, ':'))
+                            then substring-after($fn/@name, ':') else string($fn/@name)
+                        return map {
+                            "name": $prefix || ":" || $name,
+                            "signature": editor:generate-signature($fn, $prefix, $name, false()),
+                            "visibility": if ($fn/annotation/@name = "private") then "private" else "public"
+                        }
+                    },
+                    "variables": array {
+                        for $var in $module/variable[not(annotation/@name = "private")]
+                        return $prefix || ":" || substring-after($var/@name, ":")
+                    }
+                }
+            } catch * { () }
+    }
+};
+
+(:~
+ : GET /api/editor/modules — Module registry (built-in + user).
+ : Migrated from find.xq.
+ :)
+declare function editor:modules($request as map(*)) {
+    let $prefix := $request?parameters?prefix
+    return array {
+        for $uri in (util:registered-modules(), util:mapped-modules())
+        let $module :=
+            try { inspect:inspect-module-uri(xs:anyURI($uri)) } catch * { () }
+        where exists($module) and
+            (empty($prefix) or starts-with($module/@prefix, $prefix))
+        order by $module/@prefix
+        return map {
+            "prefix": $module/@prefix/string(),
+            "uri": $uri,
+            "at": $module/@location/string()
+        }
+    }
+};
+
+(:~
+ : POST /api/editor/validate — XML validation.
+ : Migrated from validate-xml.xq.
+ :)
+declare function editor:validate($request as map(*)) {
+    let $xml := $request?body
+    let $validate := ($request?parameters?validate, true())[1]
+    return
+        try {
+            let $parsed :=
+                if ($validate) then
+                    validation:jaxp-parse($xml, true(),
+                        doc("/db/apps/eXide/resources/schema/catalog.xml"))
+                else
+                    parse-xml($xml)
+            return map { "status": "valid" }
+        } catch * {
+            map {
+                "status": "invalid",
+                "errors": array {
+                    map {
+                        "line": $err:line-number,
+                        "message": $err:description
+                    }
+                }
+            }
+        }
+};
+
+(:~
+ : GET /api/editor/docs/{name} — Function documentation by name#arity.
+ :)
+declare function editor:docs($request as map(*)) {
+    let $signature := $request?parameters?name
+    let $result := editor:get-by-signature($signature)
+    return
+        if (exists($result)) then $result
+        else roaster:response(404, "application/json",
+            map { "error": "Function not found: " || $signature })
+};
+
+
+(:~
+ : GET /api/editor/imports — Discover importable modules.
+ : Migrated from atom-editor-support/module-import.xql.
+ :
+ : Returns modules available for import from two sources:
+ : 1. Package-local: scans the XAR package containing the file for library modules
+ : 2. Global: all registered and mapped modules in eXist-db
+ : Already-imported namespace URIs (passed via `uri` parameter) are excluded.
+ :)
+declare function editor:imports($request as map(*)) {
+    let $path := $request?parameters?path
+    let $prefix := $request?parameters?prefix
+    let $imported := $request?parameters?uri
+    let $imported :=
+        if ($imported instance of xs:string) then $imported
+        else if (exists($imported)) then $imported?*
+        else ()
+
+    let $path :=
+        if (starts-with($path, "xmldb:exist://")) then substring-after($path, "xmldb:exist://")
+        else $path
+
+    (: Find the package root for this file :)
+    let $pkg-root := editor:get-package-root($path)
+    let $scan-root := if (exists($pkg-root)) then $pkg-root else $path
+
+    (: Package-local modules :)
+    let $local-modules := editor:sort-modules(
+        dbutil:find-by-mimetype($scan-root, "application/xquery", function($script) {
+            for $info in editor:get-module-info($script)
+            return
+                if ($info?namespace = $imported) then ()
+                else if (empty($prefix) or $info?prefix = $prefix) then $info
+                else ()
+        })
+    )
+
+    (: Global registered/mapped modules :)
+    let $global-modules := editor:sort-modules(
+        for $uri in (util:registered-modules(), util:mapped-modules())
+        where not($uri = $imported)
+        return
+            try {
+                let $module := inspect:inspect-module-uri(xs:anyURI($uri))
+                return
+                    if (empty($prefix) or $module/@prefix = $prefix) then
+                        map {
+                            "prefix": string($module/@prefix),
+                            "namespace": string($module/@uri),
+                            "source": string($module/@location),
+                            "ref": "global"
+                        }
+                    else ()
+            } catch * { () }
+    )
+
+    return array { $local-modules, $global-modules }
+};
+
+
+(: ── Internal helpers (migrated from funcdoc.xq) ─────────── :)
+
+declare %private function editor:get-by-signature($signature as xs:string) {
+    let $name := substring-before($signature, '#')
+    let $arity := substring-after($signature, '#')
+    let $prefix := substring-before($signature, ':')
+    let $fn :=
+        try {
+            function-lookup(xs:QName(if ($prefix) then $name else 'fn:' || $name), xs:integer($arity))
+        } catch * { () }
+    return
+        if (exists($fn)) then
+            let $desc := inspect:inspect-function($fn)
+            let $function-name :=
+                if (contains($desc/@name, ':'))
+                then substring-after($desc/@name, ':')
+                else $desc/@name
+            return editor:describe-function($desc, $prefix, $function-name, true(), '')
+        else ()
+};
+
+declare %private function editor:get-built-in-functions($q as xs:string) {
+    let $supplied-prefix := if (contains($q, ':')) then substring-before($q, ':') else ()
+    let $name-fragment := if (contains($q, ':')) then substring-after($q, ':') else $q
+    let $show-fn := exists($supplied-prefix) and $supplied-prefix eq 'fn'
+    let $modules :=
+        if ($supplied-prefix eq 'fn') then
+            inspect:inspect-module-uri(xs:anyURI('http://www.w3.org/2005/xpath-functions'))
+        else
+            let $all := (util:registered-modules(), util:mapped-modules()) !
+                (try { inspect:inspect-module-uri(xs:anyURI(.)) } catch * { () })
+            return
+                if ($supplied-prefix) then $all[starts-with(@prefix, $supplied-prefix)]
+                else $all
+    let $functions := $modules/function[not(annotation/@name = "private") and not(deprecated)]
+    for $function in $functions
+    let $function-name :=
+        if (contains($function/@name, ':')) then substring-after($function/@name, ':')
+        else $function/@name
+    let $module-prefix := $function/parent::module/@prefix
+    let $complete-name :=
+        if ($show-fn) then ('fn:' || $function-name)
+        else ($module-prefix || ':' || $function-name)
+    where starts-with($complete-name, $name-fragment) or starts-with($function-name, $name-fragment)
+    order by ($module-prefix, '')[1], lower-case($function-name)
+    return editor:describe-function($function, $module-prefix, $function-name, $show-fn, $q)
+};
+
+declare %private function editor:get-imported-functions(
+    $q as xs:string?,
+    $signature as xs:string?,
+    $base as xs:string?,
+    $sources as xs:string*,
+    $uris as xs:string*,
+    $prefixes as xs:string*
+) {
+    let $supplied-prefix :=
+        if (empty($signature)) then replace($q, "^\$?([^:]+):?.*$", "$1")
+        else replace($signature, "^\$?([^:]+):?.*$", "$1")
+    for $prefix at $i in $prefixes
+    where matches($prefix, "^" || $supplied-prefix)
+    let $source-url :=
+        if (matches($sources[$i], "^(/|\w+:)")) then $sources[$i]
+        else if (exists($base)) then concat($base, "/", $sources[$i])
+        else $sources[$i]
+    return
+        try {
+            let $module := inspect:inspect-module($source-url)
+            return (
+                if (not(starts-with($q, "$")) and not(starts-with($signature, "$"))) then
+                    let $name-fragment := replace($q, "^\$?[^:]+:(.*)$", "$1")
+                    for $fn in $module/function[not(annotation/@name = "private")]
+                    let $fn-name := if (contains($fn/@name, ':')) then substring-after($fn/@name, ':') else string($fn/@name)
+                    let $arity := count($fn/argument)
+                    let $complete-name := concat($prefix, ":", $fn-name)
+                    return
+                        if ((empty($signature) or $signature = $complete-name || "#" || $arity) and
+                            (empty($q) or matches($complete-name, "^" || $q || "|:" || $q)))
+                        then map {
+                            "text": editor:generate-signature($fn, $prefix, $fn-name, false()),
+                            "name": string($fn/@name) || "#" || $arity,
+                            "leftLabel": string($fn/returns/@type) || editor:cardinality($fn/returns/@cardinality),
+                            "snippet": editor:generate-template($fn, $prefix, $fn-name, false()),
+                            "type": "function",
+                            "replacementPrefix": $q,
+                            "description": $fn/description/string(),
+                            "arguments": editor:describe-arguments($fn),
+                            "path": $source-url
+                        }
+                        else ()
+                else
+                    let $sig := substring-after($signature, "$")
+                    let $q2 := substring-after($q, "$")
+                    for $var in $module/variable[not(annotation/@name = "private")]
+                    let $var-name := concat($prefix, ":", substring-after($var/@name, ":"))
+                    return
+                        if ((not($sig) or $sig = $var-name) and
+                            (not($q2) or matches($var-name, "^" || $q2 || "|:" || $q2)))
+                        then map {
+                            "text": "$" || $var-name,
+                            "name": $var-name,
+                            "replacementPrefix": "$" || $q2,
+                            "type": "variable",
+                            "path": $source-url,
+                            "snippet": $var-name
+                        }
+                        else ()
+            )
+        } catch * { () }
+};
+
+declare %private function editor:describe-function($function, $prefix, $name, $show-fn, $q) {
+    map {
+        "text": editor:generate-signature($function, $prefix, $name, $show-fn),
+        "snippet": editor:generate-template($function, $prefix, $name, $show-fn),
+        "type": "function",
+        "description": $function/description/string(),
+        "arguments": editor:describe-arguments($function),
+        "leftLabel": string($function/returns/@type) || editor:cardinality($function/returns/@cardinality),
+        "replacementPrefix": $q
+    }
+};
+
+declare %private function editor:describe-arguments($function) {
+    array {
+        for $arg in $function/argument
+        return map {
+            "name": $arg/@var/string(),
+            "type": $arg/@type/string() || editor:cardinality($arg/@cardinality),
+            "description": $arg/string()
+        }
+    }
+};
+
+declare %private function editor:generate-signature($function, $prefix, $name, $show-fn) {
+    (if ($prefix ne '') then ($prefix || ":") else if ($show-fn) then "fn:" else ()) ||
+    $name || "(" ||
+    string-join(
+        $function/argument ! ("$" || ./@var || " as " || ./@type || editor:cardinality(./@cardinality)),
+        ", "
+    ) || ")"
+};
+
+declare %private function editor:generate-template($function, $prefix, $name, $show-fn) {
+    (if ($prefix ne '') then ($prefix || ":") else if ($show-fn) then "fn:" else ()) ||
+    $name || "(" ||
+    string-join(
+        for $param at $p in $function/argument
+        return "${" || $p || ":$" || $param/@var || "}",
+        ", "
+    ) || ")"
+};
+
+declare %private function editor:cardinality($c as xs:string) {
+    switch ($c)
+        case "zero or one" return "?"
+        case "zero or more" return "*"
+        case "one or more" return "+"
+        default return ()
+};
+
+
+(: ── Internal helpers (migrated from module-import.xql) ──── :)
+
+declare %private function editor:get-package-root($path as xs:string) as xs:string? {
+    (for $pkg in collection(repo:get-root())/expath:package[starts-with($path, util:collection-name(.))]
+     return util:collection-name($pkg))[1]
+};
+
+declare %private function editor:get-module-info($script as xs:anyURI) {
+    let $data := util:binary-doc($script)
+    let $source := util:base64-decode($data)
+    where matches($source, "^module\s+namespace", "m")
+    return
+        let $match :=
+            analyze-string($source, "^module\s+namespace\s+([^\s=]+)\s*=\s*['""]([^'""]+)['""]", "m")//fn:match
+        return
+            map {
+                "prefix": $match/fn:group[1]/string(),
+                "namespace": $match/fn:group[2]/string(),
+                "source": string($script),
+                "ref": "package"
+            }
+};
+
+declare %private function editor:sort-modules($modules as map(*)*) {
+    for $module in $modules
+    order by $module?prefix, $module?namespace
+    return $module
+};

--- a/modules/api/packages.xqm
+++ b/modules/api/packages.xqm
@@ -1,0 +1,366 @@
+(:
+ :  eXide REST API — Package management handlers.
+ :  Migrated from deployment.xq, upload.xq, util.xqm.
+ :)
+xquery version "3.1";
+
+module namespace packages="http://exist-db.org/apps/eXide/api/packages";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace config="http://exist-db.org/xquery/apps/config" at "../config.xqm";
+import module namespace dbutil="http://exist-db.org/xquery/dbutil" at "../dbutils.xqm";
+import module namespace tmpl="http://exist-db.org/xquery/template" at "../tmpl.xqm";
+
+declare namespace expath="http://expath.org/ns/pkg";
+declare namespace repo="http://exist-db.org/xquery/repo";
+
+(: Handle difference between 4.x.x and 5.x.x releases of eXist :)
+declare variable $packages:copy-resource :=
+    let $fnNew := function-lookup(xs:QName("xmldb:copy-resource"), 4)
+    return
+        if (exists($fnNew)) then $fnNew
+        else
+            let $fnOld := function-lookup(xs:QName("xmldb:copy"), 3)
+            return function($sourceCol, $sourceName, $targetCol, $targetName) {
+                $fnOld($sourceCol, $targetCol, $sourceName)
+            };
+
+declare variable $packages:ANT_FILE :=
+    <project default="xar" name="$$app$$">
+        <xmlproperty file="expath-pkg.xml"/>
+        <property name="project.version" value="${{package(version)}}"/>
+        <property name="project.app" value="$$app$$"/>
+        <property name="build.dir" value="build"/>
+        <target name="xar">
+            <mkdir dir="${{build.dir}}"/>
+            <zip basedir="." destfile="${{build.dir}}/${{project.app}}-${{project.version}}.xar"
+                excludes="${{build.dir}}/*"/>
+        </target>
+    </project>;
+
+(:~
+ : GET /api/packages — List installed packages.
+ :)
+declare function packages:list($request as map(*)) {
+    let $root := repo:get-root()
+    let $apps :=
+        for $app in xmldb:get-child-collections($root)
+        let $col := $root || $app
+        let $expath := doc($col || "/expath-pkg.xml")/expath:package
+        let $repo-meta := doc($col || "/repo.xml")/repo:meta
+        where exists($expath)
+        order by lower-case($app)
+        return map {
+            "abbrev": string($expath/@abbrev),
+            "name": string($expath/@name),
+            "title": string($expath/expath:title),
+            "version": string($expath/@version),
+            "type": string(($repo-meta/repo:type, "application")[1]),
+            "target": string($repo-meta/repo:target),
+            "path": $col
+        }
+    return map {
+        "packages": array { $apps }
+    }
+};
+
+(:~
+ : POST /api/packages — Install .xar or create new app from template.
+ :)
+declare function packages:install($request as map(*)) {
+    let $body := $request?body
+    return
+        if (exists($body?abbrev)) then
+            (: Create new app from template :)
+            packages:create-app($body)
+        else
+            (: Install uploaded .xar :)
+            packages:install-xar($request)
+};
+
+(:~
+ : GET /api/packages/{abbrev} — Package descriptor and metadata.
+ :)
+declare function packages:get($request as map(*)) {
+    let $abbrev := $request?parameters?abbrev
+    let $col := repo:get-root() || $abbrev
+    let $expath := doc($col || "/expath-pkg.xml")/expath:package
+    let $repo-meta := doc($col || "/repo.xml")/repo:meta
+    return
+        if (exists($expath)) then
+            let $user := sm:id()//sm:real/sm:username/string()
+            let $is-admin := if ($user) then sm:is-dba($user) else false()
+            return map {
+                "abbrev": string($expath/@abbrev),
+                "name": string($expath/@name),
+                "title": string($expath/expath:title),
+                "version": string($expath/@version),
+                "type": string(($repo-meta/repo:type, "application")[1]),
+                "target": string($repo-meta/repo:target),
+                "deployed": string($repo-meta/repo:deployed),
+                "description": string($repo-meta/repo:description),
+                "authors": array { $repo-meta/repo:author ! string(.) },
+                "website": string($repo-meta/repo:website),
+                "path": $col,
+                "isAdmin": $is-admin
+            }
+        else
+            roaster:response(404, "application/json",
+                map { "error": "Package not found: " || $abbrev })
+};
+
+(:~
+ : DELETE /api/packages/{abbrev} — Uninstall package.
+ :)
+declare function packages:uninstall($request as map(*)) {
+    let $abbrev := $request?parameters?abbrev
+    let $col := repo:get-root() || $abbrev
+    let $expath := doc($col || "/expath-pkg.xml")/expath:package
+    return
+        if (empty($expath)) then
+            roaster:response(404, "application/json",
+                map { "error": "Package not found: " || $abbrev })
+        else
+            try {
+                let $_ := repo:remove($expath/@name)
+                return map { "status": "ok" }
+            } catch * {
+                roaster:response(400, "application/json",
+                    map { "error": $err:description })
+            }
+};
+
+(:~
+ : POST /api/packages/{abbrev}/build — Build .xar from source collection.
+ :)
+declare function packages:build($request as map(*)) {
+    let $abbrev := $request?parameters?abbrev
+    let $col := repo:get-root() || $abbrev
+    let $expath := doc($col || "/expath-pkg.xml")/expath:package
+    return
+        if (empty($expath)) then
+            roaster:response(404, "application/json",
+                map { "error": "Package not found: " || $abbrev })
+        else
+            try {
+                let $name := $expath/@abbrev || "-" || $expath/@version || ".xar"
+                let $xar := compression:zip(xs:anyURI($col), true(), $col)
+                return roaster:response(200, "application/zip", $xar,
+                    map {
+                        "Content-Disposition": "attachment; filename=" || $name
+                    })
+            } catch * {
+                roaster:response(400, "application/json",
+                    map { "error": $err:description })
+            }
+};
+
+(:~
+ : POST /api/packages/{abbrev}/deploy — Deploy package to target collection.
+ :)
+declare function packages:deploy($request as map(*)) {
+    let $abbrev := $request?parameters?abbrev
+    let $col := repo:get-root() || $abbrev
+    let $expath := doc($col || "/expath-pkg.xml")/expath:package
+    return
+        if (empty($expath)) then
+            roaster:response(404, "application/json",
+                map { "error": "Package not found: " || $abbrev })
+        else
+            try {
+                let $xar-name := $expath/@abbrev || "-" || $expath/@version || ".xar"
+                let $xar := compression:zip(xs:anyURI($col), true(), $col)
+                let $_ := packages:mkcol("/db/system/repo", (), ())
+                let $pkg := xmldb:store("/db/system/repo", $xar-name, $xar, "application/zip")
+                let $_ := (
+                    repo:remove($expath/@name),
+                    repo:install-and-deploy-from-db($pkg)
+                )
+                return map {
+                    "status": "ok",
+                    "path": $col
+                }
+            } catch * {
+                roaster:response(400, "application/json",
+                    map { "error": $err:description })
+            }
+};
+
+(:~
+ : POST /api/packages/{abbrev}/config — Apply collection.xconf and reindex.
+ :)
+declare function packages:config($request as map(*)) {
+    let $abbrev := $request?parameters?abbrev
+    let $body := $request?body
+    let $config-xml := $body?config
+    let $collection := ($body?collection, repo:get-root() || $abbrev)[1]
+    return
+        try {
+            let $config-col := "/db/system/config" || $collection
+            let $_ := packages:mkcol($config-col, (), ())
+            let $_ := xmldb:store($config-col, "collection.xconf", $config-xml, "text/xml")
+            let $_ := xmldb:reindex($collection)
+            return map {
+                "status": "ok",
+                "collection": $collection
+            }
+        } catch * {
+            roaster:response(400, "application/json",
+                map { "error": $err:description })
+        }
+};
+
+
+(: ── Internal helpers ─────────────────────────────────────── :)
+
+declare %private function packages:install-xar($request as map(*)) {
+    let $body := $request?body
+    return
+        try {
+            (: Body is expected to be a binary XAR :)
+            let $_ := packages:mkcol("/db/system/repo", (), ())
+            let $pkg := xmldb:store("/db/system/repo", "upload.xar", $body, "application/zip")
+            let $descriptors := packages:get-xar-descriptors($pkg)
+            let $app-name := $descriptors/expath:package/@name
+            let $_ := (
+                repo:remove($app-name),
+                repo:install-and-deploy-from-db($pkg)
+            )
+            return
+                roaster:response(201, "application/json", map {
+                    "status": "ok",
+                    "name": string($app-name),
+                    "abbrev": string($descriptors/expath:package/@abbrev)
+                })
+        } catch * {
+            roaster:response(400, "application/json",
+                map { "error": $err:description })
+        }
+};
+
+declare %private function packages:get-xar-descriptors($zipPath) {
+    let $binary := util:binary-doc($zipPath)
+    return
+        if (exists($binary)) then
+            let $dataCb := function($path as xs:anyURI, $type as xs:string, $data as item()?, $param as item()*) { $data }
+            let $entryCb := function($path as xs:anyURI, $type as xs:string, $param as item()*) { $path = "expath-pkg.xml" }
+            return compression:unzip($binary, $entryCb, (), $dataCb, ())
+        else
+            error(xs:QName("packages:not-found"), "XAR package not found: " || $zipPath)
+};
+
+declare %private function packages:create-app($body as map(*)) {
+    let $abbrev := $body?abbrev
+    let $template := ($body?template, "plain")[1]
+    let $title := ($body?title, $abbrev)[1]
+    let $name := ($body?name, "http://exist-db.org/apps/" || $abbrev)[1]
+    let $version := ($body?version, "0.1")[1]
+    let $target := ($body?target, $abbrev)[1]
+    let $type := ($body?type, "application")[1]
+
+    let $collection := repo:get-root() || $target
+    let $user := sm:id()//sm:real/sm:username/string()
+    let $group := sm:get-user-groups($user)[1]
+    let $permissions := "rw-rw-r--"
+
+    return
+        try {
+            let $_ := packages:mkcol($collection, ($user, $group), $permissions)
+
+            (: Store expath-pkg.xml :)
+            let $descriptor :=
+                <package xmlns="http://expath.org/ns/pkg"
+                    name="{$name}" abbrev="{$abbrev}"
+                    version="{$version}" spec="1.0">
+                    <title>{$title}</title>
+                </package>
+            let $_ := xmldb:store($collection, "expath-pkg.xml", $descriptor, "text/xml")
+
+            (: Store repo.xml :)
+            let $repo-meta :=
+                <meta xmlns="http://exist-db.org/xquery/repo">
+                    <description>{$title}</description>
+                    <type>{$type}</type>
+                    <target>{$target}</target>
+                    <prepare>pre-install.xql</prepare>
+                    <finish>post-install.xql</finish>
+                </meta>
+            let $_ := xmldb:store($collection, "repo.xml", $repo-meta, "text/xml")
+
+            (: Copy template files if available :)
+            let $template-col := $config:app-root || "/templates/" || $template
+            let $_ :=
+                if (xmldb:collection-available($template-col)) then
+                    packages:copy-templates($collection, $template-col, ($user, $group), $permissions)
+                else ()
+
+            (: Store build.xml :)
+            let $params :=
+                <parameters>
+                    <param name="app" value="{$abbrev}"/>
+                </parameters>
+            let $_ := xmldb:store($collection, "build.xml",
+                tmpl:expand-template($packages:ANT_FILE, $params))
+
+            return
+                roaster:response(201, "application/json", map {
+                    "status": "ok",
+                    "path": $collection
+                })
+        } catch * {
+            roaster:response(400, "application/json",
+                map { "error": $err:description })
+        }
+};
+
+declare %private function packages:mkcol($path, $userData as xs:string*, $permissions as xs:string?) {
+    let $path := if (starts-with($path, "/db/")) then substring-after($path, "/db/") else $path
+    return packages:mkcol-recursive("/db", tokenize($path, "/"), $userData, $permissions)
+};
+
+declare %private function packages:mkcol-recursive($collection, $components, $userData as xs:string*, $permissions as xs:string?) {
+    if (exists($components)) then
+        let $perms := if ($permissions) then packages:set-execute-bit($permissions) else "rwxr-x---"
+        let $newColl := xs:anyURI(concat($collection, "/", $components[1]))
+        let $exists := xmldb:collection-available($newColl)
+        return (
+            xmldb:create-collection($collection, $components[1]),
+            if (exists($userData) and not($exists)) then (
+                sm:chmod($newColl, $perms),
+                sm:chown($newColl, $userData[1]),
+                sm:chgrp($newColl, $userData[2])
+            ) else (),
+            packages:mkcol-recursive($newColl, subsequence($components, 2), $userData, $permissions)
+        )
+    else ()
+};
+
+declare %private function packages:set-execute-bit($permissions as xs:string) {
+    replace($permissions, "(..).(..).(..).", "$1x$2x$3x")
+};
+
+declare %private function packages:copy-templates($target as xs:string, $source as xs:string, $userData as xs:string+, $permissions as xs:string) {
+    let $_ := packages:mkcol($target, $userData, $permissions)
+    return
+        if (xmldb:collection-available($source)) then (
+            for $resource in xmldb:get-child-resources($source)
+            let $targetPath := xs:anyURI(concat($target, "/", $resource))
+            return (
+                $packages:copy-resource($source, $resource, $target, $resource),
+                let $mime := xmldb:get-mime-type($targetPath)
+                let $perms :=
+                    if ($mime eq "application/xquery") then packages:set-execute-bit($permissions)
+                    else $permissions
+                return (
+                    sm:chmod($targetPath, $perms),
+                    sm:chown($targetPath, $userData[1]),
+                    sm:chgrp($targetPath, $userData[2])
+                )
+            ),
+            for $childColl in xmldb:get-child-collections($source)
+            return packages:copy-templates(
+                concat($target, "/", $childColl),
+                concat($source, "/", $childColl),
+                $userData, $permissions)
+        ) else ()
+};

--- a/modules/api/query.xqm
+++ b/modules/api/query.xqm
@@ -1,0 +1,139 @@
+(:
+ :  eXide REST API — Query execution handlers.
+ :  Migrated from controller.xq execute/results and compile.xq.
+ :)
+xquery version "3.1";
+
+module namespace query="http://exist-db.org/apps/eXide/api/query";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace config="http://exist-db.org/xquery/apps/config" at "../config.xqm";
+
+declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+
+(:~
+ : POST /api/query — Execute XQuery and return results.
+ :)
+declare function query:execute($request as map(*)) {
+    let $body := $request?body
+    let $xquery := $body?query
+    let $base := $body?base
+    let $serialization := ($body?serialization, "adaptive")[1]
+
+    (: Check execution permission :)
+    let $user := (request:get-attribute("org.exist.login.user"), "guest")[1]
+    let $conf := config:get-configuration()
+    let $allowed := sm:is-dba($user) or (
+        $conf/restrictions/@execute-query = "yes" and (
+            $conf/restrictions/@guest = "yes" or not($user = ("guest", "nobody"))
+        )
+    )
+    return
+        if (not($allowed)) then
+            roaster:response(403, "application/json",
+                map { "error": "Query execution not allowed" })
+        else
+            let $start-time := util:system-time()
+            return
+                try {
+                    let $result := util:eval($xquery, false(), (), false())
+                    let $elapsed := seconds-from-duration(util:system-time() - $start-time)
+                    let $count := count($result)
+
+                    (: Store results in session for pagination :)
+                    let $session-id := util:uuid()
+                    let $_ := session:set-attribute("results_" || $session-id, $result)
+                    let $_ := session:set-attribute("results_" || $session-id || "_count", $count)
+                    let $_ := session:set-attribute("results_" || $session-id || "_serialization", $serialization)
+
+                    return map {
+                        "id": $session-id,
+                        "count": $count,
+                        "elapsed": $elapsed,
+                        "items": array {
+                            for $item at $i in subsequence($result, 1, 20)
+                            return query:serialize-item($item, $serialization)
+                        }
+                    }
+                } catch * {
+                    let $elapsed := seconds-from-duration(util:system-time() - $start-time)
+                    return roaster:response(400, "application/json", map {
+                        "error": $err:description,
+                        "code": $err:code,
+                        "line": $err:line-number,
+                        "column": $err:column-number,
+                        "module": $err:module,
+                        "elapsed": $elapsed
+                    })
+                }
+};
+
+(:~
+ : POST /api/query/compile — Compile-check XQuery without executing.
+ : Migrated from compile.xq.
+ :)
+declare function query:compile($request as map(*)) {
+    let $body := $request?body
+    let $xquery := $body?query
+    let $base := $body?base
+    return
+        try {
+            let $_ := util:compile-query($xquery, $base)
+            return map { "errors": array {} }
+        } catch * {
+            map {
+                "errors": array {
+                    map {
+                        "line": $err:line-number,
+                        "column": $err:column-number,
+                        "message": $err:description,
+                        "code": string($err:code)
+                    }
+                }
+            }
+        }
+};
+
+(:~
+ : GET /api/query/{id}/results — Paginated result items.
+ : Replaces session.xq result retrieval.
+ :)
+declare function query:results($request as map(*)) {
+    let $id := $request?parameters?id
+    let $start := ($request?parameters?start, 1)[1]
+    let $count := ($request?parameters?count, 20)[1]
+    let $result := session:get-attribute("results_" || $id)
+    let $total := session:get-attribute("results_" || $id || "_count")
+    let $serialization := (session:get-attribute("results_" || $id || "_serialization"), "adaptive")[1]
+    return
+        if (empty($result) and empty($total)) then
+            roaster:response(404, "application/json",
+                map { "error": "Session expired or invalid query ID" })
+        else map {
+            "total": ($total, 0)[1],
+            "start": $start,
+            "count": $count,
+            "items": array {
+                for $item in subsequence($result, $start, $count)
+                return query:serialize-item($item, $serialization)
+            }
+        }
+};
+
+(:~
+ : Serialize a single result item to string for JSON transport.
+ :)
+declare %private function query:serialize-item($item, $serialization as xs:string) as xs:string {
+    if ($item instance of node()) then
+        serialize($item, <output:serialization-parameters>
+            <output:method>{
+                if ($serialization = ("html5", "xhtml", "xhtml5")) then $serialization
+                else if ($serialization = "json") then "json"
+                else if ($serialization = "text") then "text"
+                else "xml"
+            }</output:method>
+            <output:indent>yes</output:indent>
+        </output:serialization-parameters>)
+    else
+        string($item)
+};

--- a/modules/api/router.xq
+++ b/modules/api/router.xq
@@ -1,0 +1,31 @@
+(:
+ :  eXide REST API — Roaster router entry point.
+ :
+ :  All /api/* requests are forwarded here by controller.xq.
+ :  Routing is driven by ../api.json (OpenAPI 3.0 spec).
+ :)
+xquery version "3.1";
+
+declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+
+(: Handler modules — each provides functions referenced by operationId in api.json :)
+import module namespace auth="http://exist-db.org/apps/eXide/api/auth" at "auth.xqm";
+import module namespace db="http://exist-db.org/apps/eXide/api/db" at "db.xqm";
+import module namespace query="http://exist-db.org/apps/eXide/api/query" at "query.xqm";
+import module namespace editor="http://exist-db.org/apps/eXide/api/editor" at "editor.xqm";
+import module namespace templates="http://exist-db.org/apps/eXide/api/templates" at "templates.xqm";
+import module namespace packages="http://exist-db.org/apps/eXide/api/packages" at "packages.xqm";
+import module namespace search="http://exist-db.org/apps/eXide/api/search" at "search.xqm";
+import module namespace admin="http://exist-db.org/apps/eXide/api/admin" at "admin.xqm";
+import module namespace test="http://exist-db.org/apps/eXide/api/test" at "test.xqm";
+import module namespace sync="http://exist-db.org/apps/eXide/api/sync" at "sync.xqm";
+
+declare variable $local:definitions := "modules/api.json";
+
+declare function local:lookup($name as xs:string) {
+    function-lookup(xs:QName($name), 1)
+};
+
+roaster:route($local:definitions, local:lookup#1)

--- a/modules/api/search.xqm
+++ b/modules/api/search.xqm
@@ -1,0 +1,84 @@
+(:
+ :  eXide REST API — Search handler.
+ :  Migrated from search.xq (HTML → JSON).
+ :)
+xquery version "3.1";
+
+module namespace search="http://exist-db.org/apps/eXide/api/search";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace dbutil="http://exist-db.org/xquery/dbutil" at "../dbutils.xqm";
+
+declare variable $search:MIME_MAP := map {
+    "javascript": ("text/javascript", "application/x-javascript", "application/javascript"),
+    "css": ("text/css", "application/less"),
+    "xquery": "application/xquery"
+};
+
+declare variable $search:ALL_MIME_TYPES := (
+    "application/x-javascript", "application/javascript", "text/javascript",
+    "application/xquery", "text/css", "text/text", "application/less"
+);
+
+declare %private function search:escape-regex($str as xs:string?) {
+    replace($str, "([\-\[\]\(\)\{\}\*\+\?\.\^\|\$\\])", "\\$1")
+};
+
+(:~
+ : POST /api/search — Full-text search across binary resources.
+ :)
+declare function search:search($request as map(*)) {
+    let $body := $request?body
+    let $query-str := $body?query
+    let $collection := ($body?collection, "/db")[1]
+    let $type := ($body?type, "all")[1]
+    let $use-regex := ($body?regex, false())[1]
+    let $case-sensitive := ($body?caseSensitive, false())[1]
+
+    let $flags := if ($case-sensitive) then "" else "i"
+    let $search-str :=
+        if ($use-regex) then $query-str
+        else search:escape-regex($query-str)
+
+    return
+        if (empty($search-str) or $search-str = "") then
+            roaster:response(400, "application/json",
+                map { "error": "Empty search query" })
+        else
+            let $hits :=
+                if ($type = "all") then
+                    dbutil:scan(xs:anyURI($collection), function($col, $resource) {
+                        if ($resource and xmldb:get-mime-type($resource) = $search:ALL_MIME_TYPES) then
+                            search:search-resource($resource, $search-str, $flags)
+                        else ()
+                    })
+                else
+                    let $mime := $search:MIME_MAP($type)
+                    return
+                        if (exists($mime)) then
+                            dbutil:find-by-mimetype(xs:anyURI($collection), $mime,
+                                search:search-resource(?, $search-str, $flags))
+                        else ()
+            return map {
+                "query": $query-str,
+                "collection": $collection,
+                "hits": array { $hits }
+            }
+};
+
+declare %private function search:search-resource($resource, $search-str, $flags) {
+    let $binary := util:binary-doc($resource)
+    let $text := util:binary-to-string($binary)
+    let $analyzed := analyze-string($text, "^(.*?" || $search-str || ".*?)$", "m" || $flags)
+    return
+        if ($analyzed/fn:match) then
+            for $match in $analyzed/fn:match
+            let $line := count(analyze-string(string-join($match/preceding::text()), "\n")/fn:match) + 1
+            return map {
+                "resource": string($resource),
+                "name": replace($resource, "^.*/([^/]+)$", "$1"),
+                "line": $line,
+                "text": normalize-space($match/fn:group/string())
+            }
+        else ()
+};

--- a/modules/api/sync.xqm
+++ b/modules/api/sync.xqm
@@ -1,0 +1,83 @@
+(:
+ :  eXide REST API — Filesystem synchronization handler.
+ :  Migrated from synchronize.xq.
+ :)
+xquery version "3.1";
+
+module namespace sync="http://exist-db.org/apps/eXide/api/sync";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace file="http://exist-db.org/xquery/file"
+    at "java:org.exist.xquery.modules.file.FileModule";
+
+declare namespace expath="http://expath.org/ns/pkg";
+declare namespace repo="http://exist-db.org/xquery/repo";
+declare namespace git="http://exist-db.org/eXide/git";
+
+(:~
+ : POST /api/sync — Synchronize filesystem directory with database collection.
+ :)
+declare function sync:sync($request as map(*)) {
+    let $body := $request?body
+    let $collection := $body?collection
+    let $dir := ($body?dir, sync:working-dir-from-descriptor($collection))[1]
+    let $after :=
+        if (exists($body?after) and $body?after ne "") then
+            xs:dateTime($body?after)
+        else ()
+    let $indent := ($body?indent, true())[1]
+    let $expand-xincludes := ($body?expandXincludes, false())[1]
+    let $omit-xml-declaration := ($body?omitXmlDeclaration, true())[1]
+
+    return
+        if (empty($dir) or $dir = "") then
+            roaster:response(400, "application/json",
+                map { "error": "No working directory specified and none found in git.xml descriptor" })
+        else
+            try {
+                let $sync-params := map {
+                    "after": $after,
+                    "indent": $indent,
+                    "expand-xincludes": $expand-xincludes,
+                    "omit-xml-declaration": $omit-xml-declaration
+                }
+                let $output := file:sync($collection, $dir, $sync-params)
+                let $updates := $output//file:update
+                return map {
+                    "status": "ok",
+                    "collection": $collection,
+                    "dir": $dir,
+                    "updated": count($updates),
+                    "files": array {
+                        for $update in $updates
+                        return map {
+                            "collection": string($update/@collection),
+                            "name": string($update/@name),
+                            "error": string($update/file:error)
+                        }
+                    }
+                }
+            } catch * {
+                roaster:response(400, "application/json",
+                    map { "error": $err:description })
+            }
+};
+
+(: ── Internal helpers ─────────────────────────────────────── :)
+
+declare %private function sync:working-dir-from-descriptor($collection as xs:string) as xs:string? {
+    let $root := sync:get-app-root($collection)
+    return
+        if (exists($root)) then
+            doc($root || "/git.xml")/git:git/git:workingDir/string()
+        else ()
+};
+
+declare %private function sync:get-app-root($collection as xs:string) as xs:string? {
+    if (not(starts-with($collection, "/"))) then ()
+    else if (doc-available($collection || "/expath-pkg.xml")) then
+        replace($collection, "/+$", "")
+    else if (matches($collection, "^/db/+[^/]+")) then
+        sync:get-app-root(replace($collection, "^(.*)/+[^/]+/*$", "$1"))
+    else ()
+};

--- a/modules/api/templates.xqm
+++ b/modules/api/templates.xqm
@@ -1,0 +1,65 @@
+(:
+ :  eXide REST API — Template handlers.
+ :  Migrated from get-template.xq.
+ :)
+xquery version "3.1";
+
+module namespace templates="http://exist-db.org/apps/eXide/api/templates";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace config="http://exist-db.org/xquery/apps/config" at "../config.xqm";
+
+(:~
+ : GET /api/templates — Template catalog grouped by language.
+ :)
+declare function templates:list($request as map(*)) {
+    let $templates-col := $config:app-root || "/templates"
+    return
+        if (xmldb:collection-available($templates-col)) then
+            let $files := xmldb:get-child-resources($templates-col)
+            let $groups := map:merge(
+                for $file in $files
+                where not($file = "namespaces.json")
+                let $ext := replace($file, "^.*\.", "")
+                let $lang :=
+                    switch ($ext)
+                        case "xq" case "xql" case "xqm" return "xquery"
+                        case "xml" return "xml"
+                        case "html" return "html"
+                        case "css" return "css"
+                        case "js" return "javascript"
+                        default return $ext
+                let $name := replace($file, "\.[^.]+$", "")
+                group by $lang
+                return map:entry($lang, array {
+                    for $n at $i in $name
+                    return map { "name": $n[$i], "file": $file[$i] }
+                })
+            )
+            return $groups
+        else
+            map {}
+};
+
+(:~
+ : GET /api/templates/{name} — Retrieve template source code.
+ :)
+declare function templates:get($request as map(*)) {
+    let $name := $request?parameters?name
+    let $templates-col := $config:app-root || "/templates"
+    (: Try common extensions :)
+    let $candidates := ($name, $name || ".xq", $name || ".xml", $name || ".html",
+                        $name || ".css", $name || ".js", $name || ".xql", $name || ".xqm")
+    let $found :=
+        for $candidate in $candidates
+        where util:binary-doc-available($templates-col || "/" || $candidate)
+        return $candidate
+    return
+        if (exists($found)) then
+            let $path := $templates-col || "/" || $found[1]
+            return roaster:response(200, "text/plain",
+                util:binary-to-string(util:binary-doc($path)))
+        else
+            roaster:response(404, "application/json",
+                map { "error": "Template not found: " || $name })
+};

--- a/modules/api/test.xqm
+++ b/modules/api/test.xqm
@@ -1,0 +1,71 @@
+(:
+ :  eXide REST API — XQSuite test runner.
+ :  Migrated from run-test.xq.
+ :)
+xquery version "3.1";
+
+module namespace test="http://exist-db.org/apps/eXide/api/test";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace xqsuite="http://exist-db.org/xquery/xqsuite"
+    at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+
+(:~
+ : POST /api/test — Run XQSuite tests on a module.
+ :)
+declare function test:run($request as map(*)) {
+    let $source := $request?body?source
+    let $db-uri := xs:anyURI("xmldb:exist://" || $source)
+    return
+        if (not(util:binary-doc-available($db-uri))) then
+            roaster:response(400, "application/json", map {
+                "error": "Module not found or not saved in database. Save the test module to a database collection first.",
+                "source": $source
+            })
+        else
+            try {
+                let $result := xqsuite:suite(inspect:module-functions($db-uri))
+                let $serialized := serialize($result, <output:serialization-parameters>
+                    <output:method>xml</output:method>
+                    <output:indent>yes</output:indent>
+                </output:serialization-parameters>)
+
+                (: Parse the JUnit-style XML result into JSON :)
+                let $testsuite := $result/self::testsuite
+                return map {
+                    "source": $source,
+                    "tests": xs:integer(($testsuite/@tests, count($result//testcase))[1]),
+                    "failures": xs:integer(($testsuite/@failures, count($result//failure))[1]),
+                    "errors": xs:integer(($testsuite/@errors, count($result//error))[1]),
+                    "pending": xs:integer(($testsuite/@pending, 0)[1]),
+                    "time": string(($testsuite/@time, "")[1]),
+                    "testcases": array {
+                        for $tc in $result//testcase
+                        return map {
+                            "name": string($tc/@name),
+                            "class": string($tc/@class),
+                            "time": string(($tc/@time, "")[1]),
+                            "failure": if ($tc/failure) then map {
+                                "message": string($tc/failure/@message),
+                                "type": string($tc/failure/@type),
+                                "detail": string($tc/failure)
+                            } else (),
+                            "error": if ($tc/error) then map {
+                                "message": string($tc/error/@message),
+                                "type": string($tc/error/@type),
+                                "detail": string($tc/error)
+                            } else ()
+                        }
+                    },
+                    "xml": $serialized
+                }
+            } catch * {
+                roaster:response(400, "application/json", map {
+                    "error": $err:description,
+                    "code": string($err:code),
+                    "source": $source
+                })
+            }
+};


### PR DESCRIPTION
## Summary

- Introduce a structured REST API under `/api/*` using [Roaster](https://github.com/eeditiones/roaster) (OpenAPI 3.0 router for eXist-db)
- 29 endpoints across 10 handler modules covering all eXide backend operations
- Editor endpoints are wire-compatible with [atom-editor-support](https://github.com/exist-db/atom-editor-support), making this a superset replacement for the existing LSP ecosystem
- New `/api/editor/imports` endpoint (from atom-editor-support's module-import.xql)
- Foundation for IDE/LSP/agent integration with eXist-db

## Endpoints

| Tag | Endpoints |
|-----|-----------|
| auth | `POST/DELETE /api/auth/session`, `GET /api/auth/whoami` |
| db | `GET/PUT/POST/DELETE/PATCH /api/db/{path}` |
| query | `POST /api/query`, `POST /api/query/compile`, `GET /api/query/{id}/results` |
| editor | completions, symbols, modules, validate, docs, imports |
| templates | `GET /api/templates`, `GET /api/templates/{name}` |
| packages | list, install, get, uninstall, build, deploy, config |
| search | `POST /api/search` |
| admin | status, queries, kill-query |
| test | `POST /api/test` |
| sync | `POST /api/sync` |

## Files

| File | Description |
|------|-------------|
| `modules/api.json` | OpenAPI 3.0 spec (29 endpoints) |
| `modules/api/router.xq` | Roaster entry point |
| `modules/api/*.xqm` | 10 handler modules (auth, db, query, editor, templates, packages, search, admin, test, sync) |
| `controller.xq` | Route `/api/*` to Roaster |
| `expath-pkg.xml.tmpl` | Add Roaster dependency (≥1.8.0) |

Part 6 of 6 in the eXide modernization chain. Based on #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)