### PR TITLE
Wire LSP features: hover, go-to-definition, completions, symbols, outline

### DIFF
--- a/cypress/e2e/diagnostics_panel_spec.cy.js
+++ b/cypress/e2e/diagnostics_panel_spec.cy.js
@@ -1,0 +1,88 @@
+describe('Diagnostics panel', () => {
+  beforeEach(() => {
+    cy.intercept('POST', '**/api/query/compile').as('compile')
+    cy.loginXHR('admin', '')
+    cy.visit('/eXide/index.html')
+    cy.reload(true)
+    cy.get('.path', { timeout: 10000 }).should('contain', 'untitled-1')
+    cy.get('#user', { timeout: 15000 }).should('not.have.text', 'Login')
+    // Wait for initial compile to settle
+    cy.wait('@compile', { timeout: 10000 })
+  })
+
+  function setEditorContent(text) {
+    cy.window().then((win) => {
+      var view = win.eXide.app.getEditor().editor
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: text }
+      })
+      view.focus()
+    })
+  }
+
+  it('opens lint panel via Navigate menu', () => {
+    cy.get('.cm-panel-lint').should('not.exist')
+
+    cy.get('#menu-navigate-diagnostics').click({ force: true })
+
+    cy.get('.cm-panel-lint', { timeout: 3000 }).should('be.visible')
+  })
+
+  it('toggles panel closed on second click', () => {
+    cy.get('#menu-navigate-diagnostics').click({ force: true })
+    cy.get('.cm-panel-lint', { timeout: 3000 }).should('be.visible')
+
+    cy.get('#menu-navigate-diagnostics').click({ force: true })
+    cy.get('.cm-panel-lint').should('not.exist')
+  })
+
+  it('shows diagnostics for invalid XQuery', () => {
+    setEditorContent('declare function local:test() {\n  $undefined\n};')
+    // Wait for validation
+    cy.wait('@compile', { timeout: 10000 })
+    cy.wait(500)
+
+    cy.get('#menu-navigate-diagnostics').click({ force: true })
+    cy.get('.cm-panel-lint', { timeout: 3000 }).should('be.visible')
+
+    // Lint panel should list at least one diagnostic
+    cy.get('.cm-panel-lint li').should('have.length.at.least', 1)
+  })
+
+  it('clears diagnostics when code is fixed', () => {
+    // First introduce an error
+    setEditorContent('declare function local:test() {\n  $undefined\n};')
+    cy.wait('@compile', { timeout: 10000 })
+    cy.wait(500)
+
+    // Open panel and verify error exists
+    cy.get('#menu-navigate-diagnostics').click({ force: true })
+    cy.get('.cm-panel-lint', { timeout: 3000 }).should('be.visible')
+    cy.get('.cm-panel-lint li').should('have.length.at.least', 1)
+
+    // Fix the code
+    setEditorContent('1 + 1')
+    cy.wait('@compile', { timeout: 10000 })
+    cy.wait(500)
+
+    // Diagnostics should be cleared — panel shows "No diagnostics" text
+    cy.get('.cm-panel-lint').invoke('text').should('contain', 'No diagnostics')
+  })
+
+  it('error clearing: error pill disappears when code is fixed', () => {
+    // Trigger an error by setting invalid content
+    setEditorContent('declare function local:broken() { $x };\nlocal:broken()')
+    // Wait for compile to return the error
+    cy.wait('@compile', { timeout: 10000 })
+    cy.wait(500)
+
+    // Verify error appears
+    cy.get('#exide-err-pill', { timeout: 5000 }).should('have.class', 'has-error')
+
+    // Fix the error with valid code
+    setEditorContent('1 + 1')
+
+    // The error pill should eventually clear after re-validation
+    cy.get('#exide-err-pill', { timeout: 15000 }).should('not.have.class', 'has-error')
+  })
+})

--- a/cypress/e2e/native_autocomplete_spec.cy.js
+++ b/cypress/e2e/native_autocomplete_spec.cy.js
@@ -1,0 +1,119 @@
+describe('Native autocomplete for non-XQuery modes', () => {
+  beforeEach(() => {
+    cy.loginXHR('admin', '')
+    cy.visit('/eXide/index.html')
+    cy.reload(true)
+    cy.get('.cm-editor', { timeout: 10000 }).should('exist')
+    cy.get('#user', { timeout: 15000 }).should('not.have.text', 'Login')
+  })
+
+  /**
+   * Create a new document with the given file type and content.
+   * Types are: html, css, javascript, json, xml, less, markdown
+   */
+  function newDocument(type, content) {
+    cy.window().then((win) => {
+      var editor = win.eXide.app.getEditor()
+      editor.newDocument(null, type)
+    })
+    cy.wait(300)
+    if (content) {
+      cy.window().then((win) => {
+        var view = win.eXide.app.getEditor().editor
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: content },
+          selection: { anchor: content.length }
+        })
+        view.focus()
+      })
+    }
+  }
+
+  function triggerCompletion() {
+    cy.window().then((win) => {
+      var view = win.eXide.app.getEditor().editor
+      view.focus()
+      win.CM6.startCompletion(view)
+    })
+  }
+
+  function typeInEditor(text) {
+    cy.get('.cm-content').type(text, { delay: 50 })
+  }
+
+  describe('HTML completions', () => {
+    it('shows tag completions when typing <', () => {
+      newDocument('html', '')
+      typeInEditor('<d')
+      triggerCompletion()
+
+      cy.get('.cm-tooltip-autocomplete', { timeout: 5000 })
+        .should('be.visible')
+        .invoke('text')
+        .should('contain', 'div')
+    })
+
+    it('shows attribute completions inside a tag', () => {
+      newDocument('html', '<div ')
+      triggerCompletion()
+
+      cy.get('.cm-tooltip-autocomplete', { timeout: 5000 })
+        .should('be.visible')
+        .invoke('text')
+        .should('contain', 'class')
+    })
+  })
+
+  describe('CSS completions', () => {
+    it('shows property completions inside a rule', () => {
+      newDocument('css', 'body {\n  co')
+      triggerCompletion()
+
+      cy.get('.cm-tooltip-autocomplete', { timeout: 5000 })
+        .should('be.visible')
+        .invoke('text')
+        .should('contain', 'color')
+    })
+
+    it('shows multiple property suggestions', () => {
+      newDocument('css', 'body {\n  b')
+      triggerCompletion()
+
+      cy.get('.cm-tooltip-autocomplete', { timeout: 5000 })
+        .should('be.visible')
+        .invoke('text')
+        .should('match', /background|border|bottom/)
+    })
+  })
+
+  describe('JavaScript completions', () => {
+    it('shows local variable completions', () => {
+      newDocument('javascript', 'var myLongVariable = 42;\nmy')
+      triggerCompletion()
+
+      cy.get('.cm-tooltip-autocomplete', { timeout: 5000 })
+        .should('be.visible')
+        .invoke('text')
+        .should('contain', 'myLongVariable')
+    })
+  })
+
+  describe('JSON linting', () => {
+    it('shows parse error for invalid JSON', () => {
+      newDocument('json', '{ foo: bar }')
+      cy.wait(500)
+
+      // Lint gutter should show an error marker
+      cy.get('.cm-lint-marker-error', { timeout: 5000 })
+        .should('have.length.at.least', 1)
+    })
+
+    it('no errors for valid JSON', () => {
+      newDocument('json', '{\n  "name": "test",\n  "version": "1.0"\n}')
+      cy.wait(500)
+
+      cy.get('.cm-lint-marker-error').should('have.length', 0)
+    })
+  })
+
+})

--- a/cypress/e2e/outline_modes_spec.cy.js
+++ b/cypress/e2e/outline_modes_spec.cy.js
@@ -87,10 +87,10 @@ describe('Outline modes and filter', () => {
     // Type a filter that matches only some functions
     cy.get('#outline-filter').clear().type('access')
 
-    // The filter hides non-matching links via display:none on the <a>
+    // The filter hides non-matching <li> elements via display:none
     // Some items should be hidden
-    cy.get('#outline li a').then(($links) => {
-      var visible = $links.filter(function () {
+    cy.get('#outline li').then(($items) => {
+      var visible = $items.filter(function () {
         return Cypress.$(this).css('display') !== 'none'
       })
       expect(visible.length).to.be.below(totalCount)
@@ -109,9 +109,9 @@ describe('Outline modes and filter', () => {
     // Clear the filter
     cy.get('#outline-filter').clear()
 
-    // All links should be visible again
-    cy.get('#outline li a').then(($links) => {
-      var visible = $links.filter(function () {
+    // All items should be visible again
+    cy.get('#outline li').then(($items) => {
+      var visible = $items.filter(function () {
         return Cypress.$(this).css('display') !== 'none'
       })
       expect(visible.length).to.eq(totalCount)

--- a/cypress/e2e/outline_navigation_spec.cy.js
+++ b/cypress/e2e/outline_navigation_spec.cy.js
@@ -1,0 +1,209 @@
+describe('Outline navigation', () => {
+  beforeEach(() => {
+    cy.loginXHR('admin', '')
+    cy.visit('/eXide/index.html')
+    cy.reload(true)
+    cy.get('.path', { timeout: 10000 }).should('contain', 'untitled-1')
+    cy.get('#user', { timeout: 15000 }).should('not.have.text', 'Login')
+  })
+
+  function setEditorContent(text) {
+    cy.window().then((win) => {
+      var view = win.eXide.app.getEditor().editor
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: text }
+      })
+      view.focus()
+    })
+  }
+
+  function newDocument(type, content) {
+    cy.window().then((win) => {
+      var editor = win.eXide.app.getEditor()
+      editor.newDocument(null, type)
+    })
+    cy.wait(300)
+    if (content) {
+      setEditorContent(content)
+    }
+  }
+
+  function showOutline() {
+    cy.get('#tabs-outline').contains('outline').click()
+    cy.wait(300)
+  }
+
+  describe('XML outline', () => {
+    var xml = [
+      '<root>',
+      '  <header>',
+      '    <title>Test</title>',
+      '  </header>',
+      '  <body>',
+      '    <section id="intro">',
+      '      <para>Hello</para>',
+      '    </section>',
+      '    <section id="main">',
+      '      <para>World</para>',
+      '    </section>',
+      '  </body>',
+      '</root>'
+    ].join('\n')
+
+    it('shows XML elements as nested tree', () => {
+      newDocument('xml', xml)
+      showOutline()
+
+      cy.get('#outline li', { timeout: 5000 }).should('have.length.at.least', 5)
+      cy.get('#outline .outline-name').first().should('contain', 'root')
+    })
+
+    it('shows XPath signatures in tooltips', () => {
+      newDocument('xml', xml)
+      showOutline()
+
+      // Outline items should have XPath-like title attributes
+      cy.get('#outline li a', { timeout: 5000 }).first()
+        .should('have.attr', 'title')
+        .and('match', /\/root/)
+    })
+
+    it('shows hint attributes for elements with id', () => {
+      newDocument('xml', xml)
+      showOutline()
+
+      cy.get('#outline .outline-hint', { timeout: 5000 })
+        .should('have.length.at.least', 1)
+        .first()
+        .invoke('text')
+        .should('contain', 'intro')
+    })
+
+    it('uses nested <ul> structure for hierarchy', () => {
+      newDocument('xml', xml)
+      showOutline()
+
+      // Nested mode should produce <ul> children inside <li> elements
+      cy.get('#outline li ul', { timeout: 5000 })
+        .should('have.length.at.least', 1)
+    })
+
+    it('navigates to element and centers viewport on click', () => {
+      newDocument('xml', xml)
+      showOutline()
+
+      // Click the last element to trigger scroll
+      cy.get('#outline li a .outline-name').contains('section').first().parent().click()
+
+      // Editor should exist and have the cursor on or near the section element
+      cy.get('#editor .cm-editor', { timeout: 5000 }).should('exist')
+    })
+  })
+
+  describe('XML gotoSymbol', () => {
+    var xml = '<root>\n  <child1/>\n  <child2/>\n</root>'
+
+    it('opens QuickPicker with XPath items', () => {
+      newDocument('xml', xml)
+      // Wait for outline to populate (needs ensureSyntaxTree + requestAnimationFrame)
+      showOutline()
+      cy.get('#outline li', { timeout: 5000 }).should('have.length.at.least', 1)
+
+      cy.window().then((win) => {
+        win.eXide.app.getEditor().exec('gotoSymbol')
+      })
+
+      cy.get('.quick-picker', { timeout: 5000 })
+        .should('be.visible')
+
+      // Should show XPath-style items
+      cy.get('.quick-picker-list li', { timeout: 3000 })
+        .should('have.length.at.least', 1)
+        .invoke('text')
+        .should('contain', '/')
+    })
+  })
+
+  describe('JSON outline', () => {
+    var json = '{\n  "name": "test",\n  "version": "1.0",\n  "scripts": {\n    "build": "npm run build"\n  }\n}'
+
+    it('shows property keys in outline', () => {
+      newDocument('json', json)
+      showOutline()
+
+      cy.get('#outline li', { timeout: 5000 }).should('have.length.at.least', 3)
+      cy.get('#outline .outline-name').invoke('text').should('contain', 'name')
+    })
+
+    it('opens QuickPicker via gotoSymbol', () => {
+      newDocument('json', json)
+      showOutline()
+      cy.get('#outline li', { timeout: 5000 }).should('have.length.at.least', 1)
+
+      cy.window().then((win) => {
+        win.eXide.app.getEditor().exec('gotoSymbol')
+      })
+
+      cy.get('.quick-picker', { timeout: 5000 }).should('be.visible')
+    })
+  })
+
+  describe('CSS outline', () => {
+    var css = 'body {\n  color: red;\n}\n\n.header {\n  display: flex;\n}\n\n#main {\n  padding: 10px;\n}'
+
+    it('shows selectors in outline', () => {
+      newDocument('css', css)
+      showOutline()
+
+      cy.get('#outline li', { timeout: 5000 }).should('have.length.at.least', 2)
+      cy.get('#outline .outline-name').invoke('text').should('contain', 'body')
+    })
+  })
+
+  describe('JavaScript outline', () => {
+    var js = 'function greet(name) {\n  return "Hello " + name;\n}\n\nfunction add(a, b) {\n  return a + b;\n}'
+
+    it('shows functions in outline', () => {
+      newDocument('javascript', js)
+      showOutline()
+
+      cy.get('#outline li', { timeout: 5000 }).should('have.length.at.least', 2)
+      cy.get('#outline .outline-name').invoke('text').should('contain', 'greet')
+    })
+  })
+
+  describe('Markdown outline', () => {
+    var md = '# Title\n\n## Section 1\n\nContent\n\n## Section 2\n\nMore content\n\n### Subsection'
+
+    it('shows headings in outline', () => {
+      newDocument('markdown', md)
+      showOutline()
+
+      cy.get('#outline li', { timeout: 5000 }).should('have.length.at.least', 3)
+      cy.get('#outline .outline-name').invoke('text').should('contain', 'Title')
+    })
+  })
+
+  describe('Navigation flash', () => {
+    it('flashes target line on gotoLine', () => {
+      // Open config.xqm which has enough lines
+      cy.get('#directory li').contains('span', 'apps', { timeout: 5000 }).click()
+      cy.get('#directory li').contains('span', 'eXide', { timeout: 5000 }).click()
+      cy.get('#directory li').contains('span', 'modules', { timeout: 5000 }).click()
+      cy.get('#directory li').contains('span', 'config.xqm', { timeout: 5000 }).click()
+      cy.get('.path', { timeout: 10000 }).should('contain', 'config.xqm')
+
+      // Navigate to a line programmatically
+      cy.window().then((win) => {
+        var view = win.eXide.app.getEditor().editor
+        win.editorUtils.gotoLine(view, 10, 0, true)
+      })
+
+      // Flash decoration should appear briefly
+      cy.get('.cm-goto-flash', { timeout: 1000 }).should('exist')
+
+      // Flash should fade and be removed
+      cy.get('.cm-goto-flash', { timeout: 2000 }).should('not.exist')
+    })
+  })
+})

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="resources/css/font-awesome/css/font-awesome.min.css"/>
 <link rel="stylesheet" type="text/css" href="resources/css/eXide.css"/>
 <link rel="stylesheet" type="text/css" href="resources/css/funcdoc-tooltip.css"/>
+<link rel="stylesheet" type="text/css" href="resources/css/lsp-hover.css"/>
         <script type="text/javascript" src="resources/scripts/d3.v3.min.js"/>
         <script type="text/javascript" src="resources/scripts/less.min.js"/>
         <script type="text/javascript" src="resources/scripts/cm6-bundle.js"/>

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -180,7 +180,6 @@
                                     <a href="#" id="menu-navigate-history" data-command="historyBack">
                                         <span class="fa fa-history"/>Go to Last Edit</a>
                                 </li>
-                                <li class="separator"/>
                                 <li>
                                     <a href="#" id="menu-navigate-diagnostics" data-command="toggleDiagnostics">
                                         <span class="fa fa-exclamation-triangle"/>Toggle Diagnostics Panel</a>

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -769,7 +769,7 @@
                                 <li>
                                     <label for="pref-font">Font:</label>
                                     <select name="font" id="pref-font">
-                                        <option value="&#34;Ubuntu Mono&#34;,Monaco,Menlo,&#34;Droid Sans Mono&#34;,&#34;Courier New&#34;">Default</option>
+                                        <option value="Default">Default</option>
                                         <option value="&#34;Andale Mono&#34;">Andale Mono</option>
                                         <option>Consolas</option>
                                         <option value="&#34;Droid Sans Mono&#34;">Droid Sans Mono</option>
@@ -838,6 +838,10 @@
                                     <input type="checkbox" name="auto-pair" id="pref-auto-pair"/>
                                 </li>
                                 <li>
+                                    <label for="pref-autocomplete-on-type">Autocomplete as you type:</label>
+                                    <input type="checkbox" name="autocomplete-on-type" id="pref-autocomplete-on-type"/>
+                                </li>
+                                <li>
                                     <label for="pref-emmet">Enable emmet (HTML):</label>
                                     <input type="checkbox" name="emmet" id="pref-emmet"/>
                                 </li>
@@ -863,7 +867,7 @@
                             </ol>
                             <p>Tab width and tab/space mode use the editor settings above.
                                 Format code with Edit &gt; Reformat (or the keyboard shortcut).</p>
-                            <legend>XML / HTML Options</legend>
+                            <h4 class="pref-subsection">XML / HTML Options</h4>
                             <ol>
                                 <li>
                                     <label for="pref-prettier-xml-ws">Whitespace sensitivity:</label>
@@ -898,7 +902,7 @@
                                     <input type="checkbox" name="prettier-bracket-same-line" id="pref-prettier-bracket-same-line"/>
                                 </li>
                             </ol>
-                            <legend>JavaScript Options</legend>
+                            <h4 class="pref-subsection">JavaScript Options</h4>
                             <ol>
                                 <li>
                                     <label for="pref-prettier-bracket-spacing">Bracket spacing:</label>
@@ -924,7 +928,7 @@
                                     </select>
                                 </li>
                             </ol>
-                            <legend>HTML Options</legend>
+                            <h4 class="pref-subsection">HTML Options</h4>
                             <ol>
                                 <li>
                                     <label for="pref-prettier-html-ws">Whitespace sensitivity:</label>
@@ -935,7 +939,7 @@
                                     </select>
                                 </li>
                             </ol>
-                            <legend>Markdown Options</legend>
+                            <h4 class="pref-subsection">Markdown Options</h4>
                             <ol>
                                 <li>
                                     <label for="pref-prettier-prose-wrap">Prose wrap:</label>

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -180,6 +180,11 @@
                                     <a href="#" id="menu-navigate-history" data-command="historyBack">
                                         <span class="fa fa-history"/>Go to Last Edit</a>
                                 </li>
+                                <li class="separator"/>
+                                <li>
+                                    <a href="#" id="menu-navigate-diagnostics" data-command="toggleDiagnostics">
+                                        <span class="fa fa-exclamation-triangle"/>Toggle Diagnostics Panel</a>
+                                </li>
                             </ul>
                         </li>
                         <li id="menu-xquery">

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -383,6 +383,8 @@
                                     </span>
                                     <span class="status-separator">|</span>
                                     <span id="status-cursor">Ln 1, Col 1</span>
+                                    <span class="status-separator" id="status-scope-sep" style="display:none">|</span>
+                                    <span id="status-scope" style="display:none"></span>
                                     <a href="#" id="error-status"></a>
                                     <span id="exide-err-pill" role="button" tabindex="0" aria-label="Error details">
                                         <span class="fa fa-exclamation-circle"></span>

--- a/keybindings.js
+++ b/keybindings.js
@@ -46,5 +46,6 @@
     "gotoTab6": {"key": "Alt-6", "mac": "Ctrl-6"},
     "gotoTab7": {"key": "Alt-7", "mac": "Ctrl-7"},
     "gotoTab8": {"key": "Alt-8", "mac": "Ctrl-8"},
-    "gotoTab9": {"key": "Alt-9", "mac": "Ctrl-9"}
+    "gotoTab9": {"key": "Alt-9", "mac": "Ctrl-9"},
+    "toggleDiagnostics": {"key": "Ctrl-Shift-d", "mac": "Mod-Shift-d"}
 }

--- a/modules/api.json
+++ b/modules/api.json
@@ -486,6 +486,135 @@
                 }
             }
         },
+        "/api/query/symbols": {
+            "post": {
+                "summary": "Document symbol list (functions and variables)",
+                "operationId": "query:symbols",
+                "tags": ["query"],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["query"],
+                                "properties": {
+                                    "query": { "type": "string" },
+                                    "base":  { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Array of symbol items",
+                        "content": { "application/json": { "schema": { "type": "array" } } }
+                    }
+                }
+            }
+        },
+        "/api/query/completions": {
+            "post": {
+                "summary": "LSP-aware function completions",
+                "operationId": "query:completions",
+                "tags": ["query"],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["query"],
+                                "properties": {
+                                    "query":  { "type": "string" },
+                                    "prefix": { "type": "string" },
+                                    "base":   { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Array of completion items",
+                        "content": { "application/json": { "schema": { "type": "array" } } }
+                    }
+                }
+            }
+        },
+        "/api/query/hover": {
+            "post": {
+                "summary": "Get hover information for symbol at position",
+                "operationId": "query:hover",
+                "tags": [
+                    "query"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["query", "line", "column"],
+                                "properties": {
+                                    "query": { "type": "string" },
+                                    "line": { "type": "integer" },
+                                    "column": { "type": "integer" },
+                                    "base": { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Hover information",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/query/definition": {
+            "post": {
+                "summary": "Get definition location for symbol at position",
+                "operationId": "query:definition",
+                "tags": [
+                    "query"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["query", "line", "column"],
+                                "properties": {
+                                    "query": { "type": "string" },
+                                    "line": { "type": "integer" },
+                                    "column": { "type": "integer" },
+                                    "base": { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Definition location",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/query/{id}/results": {
             "get": {
                 "summary": "Retrieve paginated query results",

--- a/modules/api/query.xqm
+++ b/modules/api/query.xqm
@@ -7,6 +7,7 @@ xquery version "3.1";
 module namespace query="http://exist-db.org/apps/eXide/api/query";
 
 import module namespace roaster="http://e-editiones.org/roaster";
+import module namespace lsp="http://exist-db.org/xquery/lsp";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "../config.xqm";
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
@@ -76,22 +77,107 @@ declare function query:compile($request as map(*)) {
     let $body := $request?body
     let $xquery := $body?query
     let $base := $body?base
+    let $diagnostics := lsp:diagnostics($xquery, $base)
     return
-        try {
-            let $_ := util:compile-query($xquery, $base)
-            return map { "errors": array {} }
-        } catch * {
-            map {
-                "errors": array {
-                    map {
-                        "line": $err:line-number,
-                        "column": $err:column-number,
-                        "message": $err:description,
-                        "code": string($err:code)
-                    }
+        map {
+            "errors": array {
+                for $d in $diagnostics?*
+                return map {
+                    "line": $d?line + 1,
+                    "column": $d?column,
+                    "message": $d?message,
+                    "code": $d?code
                 }
             }
         }
+};
+
+(:~
+ : POST /api/query/symbols — Document symbol list for Navigate → Symbol.
+ : Returns all declared functions and variables with their positions.
+ :)
+declare function query:symbols($request as map(*)) {
+    let $body := $request?body
+    let $xquery := $body?query
+    let $base := $body?base
+    return lsp:symbols($xquery, $base)
+};
+
+(:~
+ : POST /api/query/completions — LSP-aware function completions.
+ :
+ : Calls lsp:completions() with the full document text so the server
+ : compiler can see user-defined functions and imported modules, then
+ : filters by $prefix and builds CM6 snippet templates.
+ :)
+declare function query:completions($request as map(*)) {
+    let $body := $request?body
+    let $xquery := $body?query
+    let $prefix := ($body?prefix, "")[1]
+    let $base := $body?base
+    let $completions := lsp:completions($xquery, $base)
+    return array {
+        for $item in $completions?*
+        let $name := replace($item?label, "#\d+$", "")
+        where $prefix = "" or starts-with($name, $prefix)
+        return map {
+            "text":        $item?detail,
+            "snippet":     query:make-snippet($item?detail),
+            "description": $item?documentation
+        }
+    }
+};
+
+(:~
+ : Build a CM6 snippet template from an LSP detail string.
+ : E.g. "count($items as item()*) as xs:integer" → "count(${1:$items})"
+ :)
+declare %private function query:make-snippet($detail as xs:string) as xs:string {
+    let $fname := replace($detail, "\(.*$", "")
+    let $params := analyze-string($detail, '\$([a-zA-Z][a-zA-Z0-9\-_\.]*)') //fn:match/fn:group[1]/string()
+    return
+        if (empty($params)) then $fname || "()"
+        else
+            $fname || "(" ||
+            string-join(
+                for $p at $i in $params
+                return "${" || $i || ":$" || $p || "}",
+                ", "
+            ) || ")"
+};
+
+(:~
+ : POST /api/query/hover — Get hover info for symbol at position.
+ :)
+declare function query:hover($request as map(*)) {
+    let $body := $request?body
+    let $xquery := $body?query
+    let $line := xs:integer($body?line)
+    let $column := xs:integer($body?column)
+    let $base := $body?base
+    let $hover := lsp:hover($xquery, $line, $column, $base)
+    return
+        if (exists($hover)) then
+            $hover
+        else
+            map {}
+};
+
+(:~
+ : POST /api/query/definition — Get definition location for symbol at position.
+ :)
+declare function query:definition($request as map(*)) {
+    let $body := $request?body
+    let $xquery := $body?query
+    let $line := xs:integer($body?line)
+    let $column := xs:integer($body?column)
+    let $base := $body?base
+    let $def := lsp:definition($xquery, $line, $column, $base)
+    return
+        if (exists($def)) then
+            $def
+        else
+            map {}
 };
 
 (:~

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -1178,6 +1178,7 @@ Sub level menu list items (undo style from Top level List Items)
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-width: 0;
 }
 .dir-breadcrumbs {
     padding: 4px 8px;
@@ -2447,10 +2448,6 @@ body.dark .eXide-dialog-content .browse-filter {
     left: 4px;
     right: 4px;
     overflow-y: auto;
-    overflow-x: none;
-}
-
-#directory-body .panel-scroller {
     overflow-x: auto;
 }
 
@@ -2487,26 +2484,32 @@ body.dark .eXide-dialog-content .browse-filter {
 }
 
 #outline {
-    font-family: -apple-system, "system-ui", "Segoe UI", Verdana, Helvetica, Arial, sans-serif !important;
-    font-size: 12px !important;
-    line-height: 1.4em;
     list-style: none;
     margin: 3px 3px 12px 3px;
     padding: 0;
+    min-width: min-content;
 }
 
 #outline li {
+    list-style-type: none;
     margin: 0 0 1px 0;
     padding: 0 0 0 3px;
     text-align: left;
 }
 
+#outline ul {
+    list-style: none;
+    padding: 0 0 0 10px;
+    margin: 0;
+}
+
+#outline li:hover {
+    background: rgba(0, 0, 0, 0.06);
+}
+
 #outline li a {
     display: block;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-width: 0;
 }
 
 #outline li.private {
@@ -3134,6 +3137,8 @@ div#valueHighLight {
     min-height: 20px;
     padding: 0px;
     margin-bottom: 20px;
+    width: max-content;
+    min-width: 100%;
 }
 
 .tree ul {
@@ -3184,8 +3189,6 @@ div#valueHighLight {
 .tree li span {
     display: block;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     color: #2d3748;
     text-decoration: none;
     flex: 1;
@@ -4285,6 +4288,9 @@ body.dark #outline-body, body.dark #directory-body {
 }
 body.dark #outline {
     color: #ccc;
+}
+body.dark #outline li:hover {
+    background: rgba(255, 255, 255, 0.07);
 }
 body.dark .tree {
     color: #e2e8f0;

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -585,6 +585,25 @@ a:link, a:visited {
     background: #3182ce;
 }
 
+/* Selection match: highlight all occurrences of selected text */
+.cm-selectionMatch {
+    background: rgba(255, 213, 79, 0.3);
+    border-radius: 2px;
+}
+
+.cm-selectionMatch-main {
+    background: rgba(255, 213, 79, 0.5);
+    border-radius: 2px;
+}
+
+body.dark .cm-selectionMatch {
+    background: rgba(255, 213, 79, 0.15);
+}
+
+body.dark .cm-selectionMatch-main {
+    background: rgba(255, 213, 79, 0.3);
+}
+
 /* Navigation flash: brief highlight on the target line */
 .cm-goto-flash {
     background: rgba(255, 213, 79, 0.4);
@@ -919,6 +938,15 @@ Sub level menu list items (undo style from Top level List Items)
 
 #status-bar .status-separator {
     color: #4a90d9;
+}
+
+#status-scope {
+    opacity: 0.7;
+    font-size: 10px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 300px;
 }
 
 #status-bar .status-right {

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -531,6 +531,11 @@ a:link, a:visited {
     overflow: auto;
 }
 
+/* Cmd+Click / Ctrl+Click go-to-definition: pointer cursor when modifier held */
+.cm-goto-clickable {
+    cursor: pointer !important;
+}
+
 /* Lint gutter markers — square badge with × / ! instead of default SVG dot.
    CM6 sets `content` on the element itself (SVG data URI), which makes it a
    replaced element. Override `content` directly to show our text character. */
@@ -578,6 +583,15 @@ a:link, a:visited {
     font-style: italic;
     line-height: 12px !important;
     background: #3182ce;
+}
+
+.cm-panel-lint {
+    max-height: 150px;
+    font-size: 12px;
+}
+
+.cm-panel-lint ul {
+    max-height: 130px;
 }
 
 .cm-lineNumbers .cm-gutterElement {

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -2589,8 +2589,19 @@ fieldset legend {
 #preferences-dialog fieldset {
     border: 1px solid #e2e8f0;
     border-radius: 5px;
-    padding: 0 14px 10px;
-    margin: 8px 0 12px;
+    padding: 0 14px 14px;
+    margin: 12px 0 16px;
+}
+
+#preferences-dialog .pref-subsection {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #4a5568;
+    border-top: 1px solid #e2e8f0;
+    margin: 14px 0 8px 12px;
+    padding-top: 12px;
 }
 
 #preferences-dialog legend {
@@ -2612,6 +2623,10 @@ fieldset legend {
     font-size: 12px;
     color: #718096;
     margin: 0 0 6px 0;
+}
+
+#preferences-dialog label {
+    width: 200px;
 }
 #preferences-dialog .pref-hint {
     font-size: 10px;
@@ -3889,6 +3904,10 @@ body.dark .eXide-dialog select {
 }
 body.dark #preferences-dialog p {
     color: #888;
+}
+body.dark #preferences-dialog .pref-subsection {
+    color: #a0aec0;
+    border-top-color: #2d3748;
 }
 body.dark #preferences-dialog .pref-grid th {
     color: #999;

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -585,6 +585,27 @@ a:link, a:visited {
     background: #3182ce;
 }
 
+/* Navigation flash: brief highlight on the target line */
+.cm-goto-flash {
+    background: rgba(255, 213, 79, 0.4);
+    animation: goto-flash-fade 1.2s ease-out forwards;
+}
+
+@keyframes goto-flash-fade {
+    0% { background: rgba(255, 213, 79, 0.4); }
+    100% { background: transparent; }
+}
+
+body.dark .cm-goto-flash {
+    background: rgba(255, 213, 79, 0.2);
+    animation: goto-flash-fade-dark 1.2s ease-out forwards;
+}
+
+@keyframes goto-flash-fade-dark {
+    0% { background: rgba(255, 213, 79, 0.2); }
+    100% { background: transparent; }
+}
+
 .cm-panel-lint {
     max-height: 150px;
     font-size: 12px;

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -888,6 +888,11 @@ Sub level menu list items (undo style from Top level List Items)
 
 #status-bar .status-right {
     margin-left: auto;
+    flex-shrink: 0;
+}
+
+#status-app, #status-type {
+    flex-shrink: 0;
 }
 
 /* ── Status bar segments (APP / TYPE) ── */
@@ -1118,6 +1123,8 @@ Sub level menu list items (undo style from Top level List Items)
     gap: 14px;
     font-size: 11px;
     color: #bee3f8;
+    min-width: 0;
+    overflow: hidden;
 }
 
 #status a:link, #status a:visited {

--- a/resources/css/eXide.css
+++ b/resources/css/eXide.css
@@ -585,6 +585,29 @@ a:link, a:visited {
     background: #3182ce;
 }
 
+/* Override CM6's default green bracket matching for a subtler look */
+.cm-matchingBracket {
+    background: rgba(43, 108, 176, 0.12) !important;
+    outline: 1px solid rgba(43, 108, 176, 0.3);
+}
+
+body.dark .cm-matchingBracket {
+    background: rgba(99, 179, 237, 0.12) !important;
+    outline-color: rgba(99, 179, 237, 0.3);
+}
+
+/* Matching tag highlight for XML/HTML */
+.cm-matchingTag {
+    background: rgba(43, 108, 176, 0.12) !important;
+    border-bottom: 1.5px solid rgba(43, 108, 176, 0.4) !important;
+    border-radius: 2px;
+}
+
+body.dark .cm-matchingTag {
+    background: rgba(99, 179, 237, 0.12) !important;
+    border-bottom-color: rgba(99, 179, 237, 0.4) !important;
+}
+
 /* Selection match: highlight all occurrences of selected text */
 .cm-selectionMatch {
     background: rgba(255, 213, 79, 0.3);

--- a/resources/css/lsp-hover.css
+++ b/resources/css/lsp-hover.css
@@ -1,0 +1,54 @@
+/*
+ * LSP hover tooltip styles.
+ *
+ * Matches the visual language of funcdoc-tooltip.css while providing
+ * a simpler layout for hover info (signature + optional description).
+ */
+
+.cm-lsp-hover {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 12px;
+    line-height: 1.4;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    max-width: 600px;
+    min-width: 200px;
+    padding: 8px 10px;
+}
+
+.cm-lsp-hover-signature {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 12px;
+    font-weight: 600;
+    color: #333;
+    word-break: break-all;
+    white-space: pre-wrap;
+    display: block;
+}
+
+.cm-lsp-hover-description {
+    margin: 6px 0 0 0;
+    padding-top: 6px;
+    border-top: 1px solid #eee;
+    color: #444;
+    font-size: 11px;
+}
+
+/* --- Dark mode --- */
+
+.dark-mode .cm-lsp-hover {
+    background: #1e1e1e;
+    border-color: #444;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.dark-mode .cm-lsp-hover-signature {
+    color: #e0e0e0;
+}
+
+.dark-mode .cm-lsp-hover-description {
+    color: #bbb;
+    border-top-color: #444;
+}

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -13,6 +13,7 @@ import '../src/parser/parser-registry.js';
 import '../src/static-analysis.js';
 import '../src/prettier-format.js';
 import '../src/funcdoc-tooltip.js';
+import '../src/lsp-hover.js';
 import '../src/semantic-highlight.js';
 import '../src/xquery-completion.js';
 import '../src/xquery-helper.js';

--- a/src/codevalidator.js
+++ b/src/codevalidator.js
@@ -70,15 +70,28 @@ eXide.edit.CodeValidator = (function () {
         }
 
         this.inProgress = true;
+        var startedAt = new Date().getTime();
         doc.getModeHelper().validate(doc, doc.getText(), function (success) {
+            // Check if document changed while compile was in flight,
+            // BEFORE updating lastValidation (which would mask the change)
+            var changedDuringValidation = doc.lastChangeEvent > startedAt;
+
             doc.lastValidation = new Date().getTime();
             self.inProgress = false;
-            self.deferred.resolve([success]);
-            self.deferred = null;
+            if (self.deferred) {
+                self.deferred.resolve([success]);
+                self.deferred = null;
+            }
 
             self.$triggerEvent("validate", [doc]);
             if (success) {
                 self.$triggerEvent("documentValid", [doc]);
+            }
+
+            // Re-validate with the newer code
+            if (changedDuringValidation && self.editor.activeDoc === doc) {
+                doc.lastValidation = 0; // force needsValidation() to return true
+                self.triggerDelayed(doc);
             }
         });
         return this.deferred;

--- a/src/commands.js
+++ b/src/commands.js
@@ -85,7 +85,8 @@ eXide.edit.commands = (function () {
         removeTags: "Remove Tags", extractFunction: "Extract Function",
         extractVariable: "Extract Variable", openTab: "Switch Editor",
         toggleQueryResults: "Toggle Results", commandPalette: "Command Palette",
-        findFiles: "Find in Files"
+        findFiles: "Find in Files",
+        toggleDiagnostics: "Toggle Diagnostics Panel"
     };
 
     function humanName(id) {
@@ -126,6 +127,10 @@ eXide.edit.commands = (function () {
                     });
                     addCommand("historyBack", getKeyBinding(kb, "historyBack"), function() {
                         parent.historyBack();
+                        return true;
+                    });
+                    addCommand("toggleDiagnostics", getKeyBinding(kb, "toggleDiagnostics"), function() {
+                        parent.toggleDiagnostics();
                         return true;
                     });
                     addCommand("fold", getKeyBinding(kb, "fold"), function(view) {

--- a/src/css-helper.js
+++ b/src/css-helper.js
@@ -34,8 +34,8 @@ eXide.edit.CssModeHelper = (function () {
     eXide.util.oop.inherit(Constr, eXide.edit.ModeHelper);
 
     Constr.prototype.createOutline = function(doc, onComplete) {
-        var tree = CM6.syntaxTree(this.editor.state);
         var state = this.editor.state;
+        var tree = CM6.ensureSyntaxTree(state, state.doc.length, 5000) || CM6.syntaxTree(state);
         tree.iterate({
             enter: function(node) {
                 if (node.name === "RuleSet") {

--- a/src/eXide.js
+++ b/src/eXide.js
@@ -184,6 +184,17 @@ eXide.app = (function(util) {
                 app.restoreState(function(restored) {
                     app.updateLayoutTop();
                     editor.init();
+
+                    // Fetch registered module prefixes for static analysis
+                    fetch("api/editor/modules")
+                        .then(function(r) { return r.json(); })
+                        .then(function(modules) {
+                            if (Array.isArray(modules) && typeof staticAnalysis !== "undefined") {
+                                staticAnalysis.setRegisteredModules(modules);
+                            }
+                        })
+                        .catch(function() {});
+
                     if (afterInitCallback) {
                         afterInitCallback(restored);
                     }
@@ -1967,6 +1978,9 @@ eXide.app = (function(util) {
             });
             menu.click("#menu-navigate-history", function() {
                 editor.historyBack();
+            });
+            menu.click("#menu-navigate-diagnostics", function() {
+                editor.toggleDiagnostics();
             });
             menu.click("#menu-view-toggle-collections", function() {
                 app.toggleCollectionsPanel();

--- a/src/editor-utils.js
+++ b/src/editor-utils.js
@@ -11,6 +11,28 @@
     var CM6 = globalThis.CM6;
     var setDiagnostics = CM6.setDiagnostics;
 
+    // -- Navigation flash effect --
+    // Briefly highlights the target line after gotoLine to draw the eye.
+    var flashEffect = CM6.StateEffect.define();
+    var flashClear = CM6.StateEffect.define();
+    var flashDeco = CM6.Decoration.line({ class: "cm-goto-flash" });
+    var flashField = CM6.StateField.define({
+        create: function () { return CM6.Decoration.none; },
+        update: function (value, tr) {
+            for (var i = 0; i < tr.effects.length; i++) {
+                if (tr.effects[i].is(flashEffect)) {
+                    var line = tr.state.doc.lineAt(tr.effects[i].value);
+                    return CM6.Decoration.set([flashDeco.range(line.from)]);
+                }
+                if (tr.effects[i].is(flashClear)) {
+                    return CM6.Decoration.none;
+                }
+            }
+            return value;
+        },
+        provide: function (f) { return CM6.EditorView.decorations.from(f); }
+    });
+
     /**
      * Convert a CM6 offset to a 0-indexed {row, column} position.
      */
@@ -43,6 +65,11 @@
         view.dispatch({
             effects: CM6.EditorView.scrollIntoView(offset, { y: "center" })
         });
+        // Flash the target line
+        view.dispatch({ effects: flashEffect.of(offset) });
+        setTimeout(function () {
+            view.dispatch({ effects: flashClear.of(null) });
+        }, 1200);
         view.focus();
     }
 
@@ -131,6 +158,7 @@
         textToScreenCoordinates: textToScreenCoordinates,
         setAnnotations: setAnnotations,
         getAnnotations: getAnnotations,
-        clearAnnotations: clearAnnotations
+        clearAnnotations: clearAnnotations,
+        flashField: flashField
     };
 })();

--- a/src/editor-utils.js
+++ b/src/editor-utils.js
@@ -38,8 +38,10 @@
         var row = Math.max(0, line - 1);
         var offset = rowColToOffset(view.state, row, column || 0);
         view.dispatch({
-            selection: { anchor: offset },
-            scrollIntoView: true
+            selection: { anchor: offset }
+        });
+        view.dispatch({
+            effects: CM6.EditorView.scrollIntoView(offset, { y: "center" })
         });
         view.focus();
     }

--- a/src/editor.js
+++ b/src/editor.js
@@ -269,6 +269,7 @@ eXide.edit.Editor = (function () {
             showInvisiblesCompartment.of([]),
             rectangularSelectionCompartment.of([CM6.rectangularSelection(), CM6.crosshairCursor()]),
             eXide.edit.FuncDocTooltip.extension(),
+            eXide.edit.LspHover.extension(),
             eXide.edit.SemanticHighlight.extension(),
             CM6.autocompletion({
                 override: [eXide.edit.CompletionSource.completionSource],

--- a/src/editor.js
+++ b/src/editor.js
@@ -38,6 +38,7 @@ eXide.edit.Document = (function() {
         this.externalLink = null;
         this.lastChangeEvent = new Date().getTime();
         this.lastValidation = 0;
+        this.lastParsed = 0;
         this.ast = null;
 
         // CM6: store the document text; the EditorState will be created
@@ -713,6 +714,7 @@ eXide.edit.Editor = (function () {
         editorUtils.clearAnnotations(this.editor);
         this.activeDoc.ast = null;
         this.activeDoc.lastValidation = 0;
+        this.activeDoc.lastParsed = 0;
         this.validator.triggerNow(this.activeDoc);
     };
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -281,6 +281,7 @@ eXide.edit.Editor = (function () {
                 icons: true
             })),
             CM6.scrollPastEnd(),
+            editorUtils.flashField,
             EditorView.domEventHandlers({
                 click: function(event, view) {
                     // Cmd+Click (Mac) or Ctrl+Click (other) → go to definition

--- a/src/editor.js
+++ b/src/editor.js
@@ -281,6 +281,32 @@ eXide.edit.Editor = (function () {
                 icons: true
             })),
             CM6.scrollPastEnd(),
+            EditorView.domEventHandlers({
+                click: function(event, view) {
+                    // Cmd+Click (Mac) or Ctrl+Click (other) → go to definition
+                    var isMac = /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+                    if ((isMac && event.metaKey) || (!isMac && event.ctrlKey)) {
+                        event.preventDefault();
+                        $this.exec("gotoDefinition");
+                        return true;
+                    }
+                },
+                keydown: function(event, view) {
+                    var isMac = /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+                    if ((isMac && event.key === "Meta") || (!isMac && event.key === "Control")) {
+                        view.contentDOM.classList.add("cm-goto-clickable");
+                    }
+                },
+                keyup: function(event, view) {
+                    var isMac = /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+                    if ((isMac && event.key === "Meta") || (!isMac && event.key === "Control")) {
+                        view.contentDOM.classList.remove("cm-goto-clickable");
+                    }
+                },
+                blur: function(event, view) {
+                    view.contentDOM.classList.remove("cm-goto-clickable");
+                }
+            }),
             EditorView.updateListener.of(function(update) {
                 if (update.docChanged && $this.activeDoc && !$this._switching) {
                     if ($this.activeDoc.saved) {
@@ -914,6 +940,15 @@ eXide.edit.Editor = (function () {
 
     Constr.prototype.clearErrors = function () {
         editorUtils.clearAnnotations(this.editor);
+    };
+
+    Constr.prototype.toggleDiagnostics = function () {
+        var panel = this.editor.dom.querySelector(".cm-panel-lint");
+        if (panel) {
+            CM6.closeLintPanel(this.editor);
+        } else {
+            CM6.openLintPanel(this.editor);
+        }
     };
 
     Constr.prototype.forEachDocument = function(callback) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -252,6 +252,7 @@ eXide.edit.Editor = (function () {
             CM6.history(),
             CM6.foldGutter(),
             CM6.bracketMatching(),
+            CM6.highlightSelectionMatches({ highlightWordAroundCursor: true }),
             autoPairCompartment.of([CM6.closeBrackets(), keymap.of(CM6.closeBracketsKeymap)]),
             CM6.indentOnInput(),
             CM6.syntaxHighlighting(CM6.defaultHighlightStyle, { fallback: true }),
@@ -326,6 +327,26 @@ eXide.edit.Editor = (function () {
                     var el = document.getElementById("status-cursor");
                     if (el) {
                         el.textContent = "Ln " + line.number + ", Col " + col;
+                    }
+                    // Update scope breadcrumb for XQuery
+                    var scopeEl = document.getElementById("status-scope");
+                    var scopeSep = document.getElementById("status-scope-sep");
+                    if (scopeEl && $this.activeDoc && $this.activeDoc.ast &&
+                        $this.activeDoc.getSyntax() === "xquery") {
+                        var pos = { line: line.number - 1, col: col - 1 };
+                        var node = eXide.edit.XQueryUtils.findNode($this.activeDoc.ast, pos);
+                        if (node) {
+                            var path = eXide.edit.XQueryUtils.getPath(node);
+                            scopeEl.textContent = path;
+                            scopeEl.style.display = "";
+                            scopeSep.style.display = "";
+                        } else {
+                            scopeEl.style.display = "none";
+                            scopeSep.style.display = "none";
+                        }
+                    } else if (scopeEl) {
+                        scopeEl.style.display = "none";
+                        scopeSep.style.display = "none";
                     }
                 }
             })

--- a/src/editor.js
+++ b/src/editor.js
@@ -274,6 +274,7 @@ eXide.edit.Editor = (function () {
             rectangularSelectionCompartment.of([CM6.rectangularSelection(), CM6.crosshairCursor()]),
             eXide.edit.FuncDocTooltip.extension(),
             eXide.edit.LspHover.extension(),
+            eXide.edit.TagMatching.extension(),
             eXide.edit.SemanticHighlight.extension(),
             autocompletionCompartment.of(CM6.autocompletion({
                 override: [eXide.edit.CompletionSource.completionSource],
@@ -328,25 +329,63 @@ eXide.edit.Editor = (function () {
                     if (el) {
                         el.textContent = "Ln " + line.number + ", Col " + col;
                     }
-                    // Update scope breadcrumb for XQuery
+                    // Update scope breadcrumb
                     var scopeEl = document.getElementById("status-scope");
                     var scopeSep = document.getElementById("status-scope-sep");
-                    if (scopeEl && $this.activeDoc && $this.activeDoc.ast &&
-                        $this.activeDoc.getSyntax() === "xquery") {
-                        var pos = { line: line.number - 1, col: col - 1 };
-                        var node = eXide.edit.XQueryUtils.findNode($this.activeDoc.ast, pos);
-                        if (node) {
-                            var path = eXide.edit.XQueryUtils.getPath(node);
-                            scopeEl.textContent = path;
+                    if (scopeEl && $this.activeDoc) {
+                        var syntax = $this.activeDoc.getSyntax();
+                        var scopePath = null;
+
+                        if (syntax === "xquery" && $this.activeDoc.ast) {
+                            var pos = { line: line.number - 1, col: col - 1 };
+                            var node = eXide.edit.XQueryUtils.findNode($this.activeDoc.ast, pos);
+                            if (node) {
+                                scopePath = eXide.edit.XQueryUtils.getPath(node);
+                            }
+                        } else if (syntax === "xml" || syntax === "html") {
+                            // Walk CM6 syntax tree to build XPath at cursor
+                            var tree = CM6.syntaxTree(update.state);
+                            var treeNode = tree.resolveInner(head, -1);
+                            var steps = [];
+                            var cur = treeNode;
+                            while (cur) {
+                                if (cur.name === "Element" || cur.name === "SelfClosingTag") {
+                                    // Find TagName child
+                                    var child = cur.firstChild;
+                                    while (child) {
+                                        if (child.name === "TagName") {
+                                            steps.unshift(update.state.sliceDoc(child.from, child.to));
+                                            break;
+                                        }
+                                        if (child.name === "OpenTag" || child.name === "SelfClosingTag") {
+                                            var gc = child.firstChild;
+                                            while (gc) {
+                                                if (gc.name === "TagName") {
+                                                    steps.unshift(update.state.sliceDoc(gc.from, gc.to));
+                                                    break;
+                                                }
+                                                gc = gc.nextSibling;
+                                            }
+                                            break;
+                                        }
+                                        child = child.nextSibling;
+                                    }
+                                }
+                                cur = cur.parent;
+                            }
+                            if (steps.length > 0) {
+                                scopePath = "/" + steps.join("/");
+                            }
+                        }
+
+                        if (scopePath) {
+                            scopeEl.textContent = scopePath;
                             scopeEl.style.display = "";
                             scopeSep.style.display = "";
                         } else {
                             scopeEl.style.display = "none";
                             scopeSep.style.display = "none";
                         }
-                    } else if (scopeEl) {
-                        scopeEl.style.display = "none";
-                        scopeSep.style.display = "none";
                     }
                 }
             })

--- a/src/editor.js
+++ b/src/editor.js
@@ -226,7 +226,7 @@ eXide.edit.Editor = (function () {
             case "less":
                 return CM6.css(); // Less uses CSS mode
             case "json":
-                return CM6.json();
+                return [CM6.json(), CM6.jsonParseLinter ? CM6.linter(CM6.jsonParseLinter()) : []];
             case "markdown":
                 return CM6.markdown();
             default:
@@ -273,7 +273,7 @@ eXide.edit.Editor = (function () {
             eXide.edit.SemanticHighlight.extension(),
             CM6.autocompletion({
                 override: [eXide.edit.CompletionSource.completionSource],
-                activateOnTyping: false,
+                activateOnTyping: true,
                 maxRenderedOptions: 50,
                 icons: true
             }),

--- a/src/editor.js
+++ b/src/editor.js
@@ -190,6 +190,8 @@ eXide.edit.Editor = (function () {
     var showInvisiblesCompartment = new Compartment();
     // Rectangular selection compartment
     var rectangularSelectionCompartment = new Compartment();
+    // Autocompletion compartment (for toggling activateOnTyping)
+    var autocompletionCompartment = new Compartment();
 
     function parseErrMsg(error) {
         var msg;
@@ -271,12 +273,12 @@ eXide.edit.Editor = (function () {
             eXide.edit.FuncDocTooltip.extension(),
             eXide.edit.LspHover.extension(),
             eXide.edit.SemanticHighlight.extension(),
-            CM6.autocompletion({
+            autocompletionCompartment.of(CM6.autocompletion({
                 override: [eXide.edit.CompletionSource.completionSource],
                 activateOnTyping: true,
                 maxRenderedOptions: 50,
                 icons: true
-            }),
+            })),
             CM6.scrollPastEnd(),
             EditorView.updateListener.of(function(update) {
                 if (update.docChanged && $this.activeDoc && !$this._switching) {
@@ -343,6 +345,7 @@ eXide.edit.Editor = (function () {
         this._lineWrappingCompartment = lineWrappingCompartment;
         this._showInvisiblesCompartment = showInvisiblesCompartment;
         this._rectangularSelectionCompartment = rectangularSelectionCompartment;
+        this._autocompletionCompartment = autocompletionCompartment;
         this._baseExtensions = buildExtensions;
 
         // register keybindings

--- a/src/javascript-helper.js
+++ b/src/javascript-helper.js
@@ -37,8 +37,8 @@ eXide.edit.JavascriptModeHelper = (function () {
     eXide.util.oop.inherit(Constr, eXide.edit.ModeHelper);
 
     Constr.prototype.createOutline = function(doc, onComplete) {
-        var tree = CM6.syntaxTree(this.editor.state);
         var state = this.editor.state;
+        var tree = CM6.ensureSyntaxTree(state, state.doc.length, 5000) || CM6.syntaxTree(state);
         tree.iterate({
             enter: function(node) {
                 var name = null, type = eXide.edit.Document.TYPE_FUNCTION, sig = null;

--- a/src/json-helper.js
+++ b/src/json-helper.js
@@ -33,8 +33,8 @@ eXide.edit.JsonModeHelper = (function () {
     eXide.util.oop.inherit(Constr, eXide.edit.ModeHelper);
 
     Constr.prototype.createOutline = function(doc, onComplete) {
-        var tree = CM6.syntaxTree(this.editor.state);
         var state = this.editor.state;
+        var tree = CM6.ensureSyntaxTree(state, state.doc.length, 5000) || CM6.syntaxTree(state);
         var depth = 0;
         tree.iterate({
             enter: function(node) {

--- a/src/json-helper.js
+++ b/src/json-helper.js
@@ -28,6 +28,7 @@ eXide.edit.JsonModeHelper = (function () {
         this.editor = this.parent.editor;
         this.addCommand("locate", this.locate);
         this.addCommand("format", this.format);
+        this.addCommand("gotoSymbol", this.gotoSymbol);
     };
 
     eXide.util.oop.inherit(Constr, eXide.edit.ModeHelper);

--- a/src/less-helper.js
+++ b/src/less-helper.js
@@ -46,6 +46,7 @@ eXide.edit.LessModeHelper = (function () {
         this.editor = this.parent.editor;
         this.addCommand("locate", this.locate);
         this.addCommand("format", this.format);
+        this.addCommand("gotoSymbol", this.gotoSymbol);
     };
 
     eXide.util.oop.inherit(Constr, eXide.edit.ModeHelper);

--- a/src/less-helper.js
+++ b/src/less-helper.js
@@ -82,8 +82,8 @@ eXide.edit.LessModeHelper = (function () {
     Constr.prototype.saveCSS = saveCSS;
 
     Constr.prototype.createOutline = function(doc, onComplete) {
-        var tree = CM6.syntaxTree(this.editor.state);
         var state = this.editor.state;
+        var tree = CM6.ensureSyntaxTree(state, state.doc.length, 5000) || CM6.syntaxTree(state);
         tree.iterate({
             enter: function(node) {
                 if (node.name === "RuleSet") {

--- a/src/lsp-hover.js
+++ b/src/lsp-hover.js
@@ -1,0 +1,117 @@
+/*
+ *  eXide - web-based XQuery IDE
+ *
+ *  Copyright (C) 2013 Wolfgang Meier
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * LSP hover tooltip for XQuery mode.
+ *
+ * Uses CM6's hoverTooltip to show function signatures and variable info
+ * when the user hovers over symbols. Fetches data from the server-side
+ * lsp:hover() function via /api/query/hover.
+ */
+eXide.namespace("eXide.edit.LspHover");
+
+eXide.edit.LspHover = (function () {
+
+    var hoverTooltip = CM6.hoverTooltip;
+
+    function lspHoverSource(view, pos, side) {
+        // Only hover in XQuery mode
+        var doc = eXide.app && eXide.app.getEditor && eXide.app.getEditor().getActiveDocument();
+        if (!doc || doc.getSyntax() !== "xquery") {
+            return null;
+        }
+
+        var line = view.state.doc.lineAt(pos);
+        var lineNumber = line.number - 1;  // 0-based for LSP
+        var column = pos - line.from;      // 0-based column
+
+        var code = view.state.doc.toString();
+        var basePath = "xmldb:exist://" + (doc.getBasePath ? doc.getBasePath() : "/db");
+
+        return fetch("api/query/hover", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                query: code,
+                line: lineNumber,
+                column: column,
+                base: basePath
+            })
+        })
+        .then(function (response) { return response.json(); })
+        .then(function (data) {
+            if (!data || !data.contents) {
+                return null;
+            }
+
+            // Find the word boundaries at the hover position for highlighting
+            var wordStart = pos;
+            var wordEnd = pos;
+            var text = line.text;
+            var col = column;
+
+            while (col > 0 && /[\w:\-$]/.test(text[col - 1])) {
+                col--;
+                wordStart--;
+            }
+            col = column;
+            while (col < text.length && /[\w:\-]/.test(text[col])) {
+                col++;
+                wordEnd++;
+            }
+
+            return {
+                pos: wordStart,
+                end: wordEnd,
+                above: true,
+                create: function () {
+                    var dom = document.createElement("div");
+                    dom.className = "cm-lsp-hover";
+
+                    var sig = document.createElement("code");
+                    sig.className = "cm-lsp-hover-signature";
+                    sig.textContent = data.contents.split("\n\n")[0];
+                    dom.appendChild(sig);
+
+                    // Documentation (after the signature)
+                    var parts = data.contents.split("\n\n");
+                    if (parts.length > 1) {
+                        var desc = document.createElement("p");
+                        desc.className = "cm-lsp-hover-description";
+                        desc.textContent = parts.slice(1).join("\n\n");
+                        dom.appendChild(desc);
+                    }
+
+                    return { dom: dom };
+                }
+            };
+        })
+        .catch(function () {
+            return null;
+        });
+    }
+
+    function extension() {
+        return hoverTooltip(lspHoverSource, { hoverTime: 300 }).extension;
+    }
+
+    return {
+        extension: extension
+    };
+}());

--- a/src/lsp-hover.js
+++ b/src/lsp-hover.js
@@ -57,7 +57,8 @@ eXide.edit.LspHover = (function () {
         .then(function (response) { return response.json(); })
         .then(function (data) {
             if (!data || !data.contents) {
-                return null;
+                // Fallback: look up local function signature from AST
+                return localHoverFallback(view, pos, line, column);
             }
 
             // Find the word boundaries at the hover position for highlighting
@@ -105,6 +106,77 @@ eXide.edit.LspHover = (function () {
         .catch(function () {
             return null;
         });
+    }
+
+    /**
+     * Client-side hover fallback: look up local function/variable from AST
+     * when the server's lsp:hover() returns nothing.
+     */
+    function localHoverFallback(view, pos, line, column) {
+        var doc = eXide.app.getEditor().getActiveDocument();
+        if (!doc || !doc.ast) return null;
+
+        var lead = { line: line.number - 1, col: column };
+        var astNode = eXide.edit.XQueryUtils.findNode(doc.ast, lead);
+        if (!astNode) return null;
+
+        // Check if we're on a FunctionCall
+        var fcall = eXide.edit.XQueryUtils.findAncestor(astNode, "FunctionCall");
+        var signature = null;
+        if (fcall) {
+            var nameNode = eXide.edit.XQueryUtils.findChild(fcall, "EQName");
+            if (nameNode) {
+                var funcName = eXide.edit.XQueryUtils.getValue(nameNode);
+                var arity = fcall.arity || 0;
+                // Search outline for matching function
+                for (var i = 0; i < doc.functions.length; i++) {
+                    var f = doc.functions[i];
+                    if (f.type === "function" && f.name === funcName) {
+                        signature = f.signature || funcName + "#" + arity;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Check if we're on a VarRef
+        if (!signature) {
+            var varRef = eXide.edit.XQueryUtils.findAncestor(astNode, ["VarRef", "VarName"]);
+            if (varRef) {
+                var varEQName = eXide.edit.XQueryUtils.findChild(
+                    varRef.name === "VarRef" ? varRef : varRef, "EQName"
+                );
+                if (varEQName) {
+                    signature = "$" + eXide.edit.XQueryUtils.getValue(varEQName);
+                }
+            }
+        }
+
+        if (!signature) return null;
+
+        // Build word boundaries for tooltip positioning
+        var wordStart = pos;
+        var wordEnd = pos;
+        var text = line.text;
+        var col = column;
+        while (col > 0 && /[\w:\-$]/.test(text[col - 1])) { col--; wordStart--; }
+        col = column;
+        while (col < text.length && /[\w:\-]/.test(text[col])) { col++; wordEnd++; }
+
+        return {
+            pos: wordStart,
+            end: wordEnd,
+            above: true,
+            create: function () {
+                var dom = document.createElement("div");
+                dom.className = "cm-lsp-hover";
+                var sig = document.createElement("code");
+                sig.className = "cm-lsp-hover-signature";
+                sig.textContent = signature;
+                dom.appendChild(sig);
+                return { dom: dom };
+            }
+        };
     }
 
     function extension() {

--- a/src/markdown-helper.js
+++ b/src/markdown-helper.js
@@ -28,6 +28,7 @@ eXide.edit.MarkdownModeHelper = (function () {
         this.editor = this.parent.editor;
         this.addCommand("locate", this.locate);
         this.addCommand("format", this.format);
+        this.addCommand("gotoSymbol", this.gotoSymbol);
     };
 
     eXide.util.oop.inherit(Constr, eXide.edit.ModeHelper);

--- a/src/markdown-helper.js
+++ b/src/markdown-helper.js
@@ -33,8 +33,8 @@ eXide.edit.MarkdownModeHelper = (function () {
     eXide.util.oop.inherit(Constr, eXide.edit.ModeHelper);
 
     Constr.prototype.createOutline = function(doc, onComplete) {
-        var tree = CM6.syntaxTree(this.editor.state);
         var state = this.editor.state;
+        var tree = CM6.ensureSyntaxTree(state, state.doc.length, 5000) || CM6.syntaxTree(state);
         tree.iterate({
             enter: function(node) {
                 var level = 0;

--- a/src/mode-helper.js
+++ b/src/mode-helper.js
@@ -71,8 +71,8 @@ eXide.edit.ModeHelper = (function () {
         },
 
         collectErrors: function(doc) {
-            var tree = CM6.syntaxTree(this.editor.state);
             var state = this.editor.state;
+            var tree = CM6.ensureSyntaxTree(state, state.doc.length, 5000) || CM6.syntaxTree(state);
             tree.iterate({
                 enter: function(node) {
                     if (node.type.isError) {

--- a/src/mode-helper.js
+++ b/src/mode-helper.js
@@ -31,6 +31,7 @@ eXide.edit.ModeHelper = (function () {
         this.commands = {};
         this.addCommand("locate", this.locate);
         this.addCommand("format", this.format);
+        this.addCommand("gotoSymbol", this.gotoSymbol);
     }
 
     Constr.prototype = {
@@ -49,12 +50,13 @@ eXide.edit.ModeHelper = (function () {
         },
 
         exec: function (command, doc, args) {
-            if (this.commands && this.commands[command]) {
+            var fn = (this.commands && this.commands[command]) || this[command];
+            if (typeof fn === "function") {
                 var nargs = [doc];
                 for (var i = 0; i < args.length; i++) {
                     nargs.push(args[i]);
                 }
-                this.commands[command].apply(this, nargs);
+                fn.apply(this, nargs);
             } else {
                 eXide.util.message(command + " not supported in this mode.")
             }
@@ -140,6 +142,37 @@ eXide.edit.ModeHelper = (function () {
                 console.log("Error formatting code: %s", e.message);
                 eXide.util.error("Code could not be formatted: " + e.message);
             });
+        },
+
+        gotoSymbol: function(doc) {
+            var self = this;
+            if (!doc.functions || doc.functions.length === 0) {
+                eXide.util.message("No symbols found.");
+                return;
+            }
+            var items = doc.functions.map(function(f) {
+                return {
+                    label: f.signature || f.name,
+                    name: f.name,
+                    row: f.row,
+                    from: f.from
+                };
+            });
+            eXide.util.QuickPicker.show(items, function(selected) {
+                if (selected) {
+                    if (selected.from !== undefined) {
+                        self.editor.dispatch({
+                            selection: { anchor: selected.from }
+                        });
+                        self.editor.dispatch({
+                            effects: CM6.EditorView.scrollIntoView(selected.from, { y: "center" })
+                        });
+                        self.editor.focus();
+                    } else if (selected.row !== undefined) {
+                        editorUtils.gotoLine(self.editor, selected.row + 1, 0, true);
+                    }
+                }
+            }, { placeholder: "Go to symbol\u2026", parentEditor: self.editor });
         },
 
         getTemplates: function (doc, prefix, popupItems) {

--- a/src/outline.js
+++ b/src/outline.js
@@ -135,7 +135,6 @@ eXide.edit.Outline = (function () {
 
             var helper = doc.getModeHelper();
             if (helper != null && this.__activated) {
-                doc.functions = [];
                 helper.createOutline(doc, function() {
                     self.$outlineUpdate(doc);
                 });
@@ -217,7 +216,10 @@ eXide.edit.Outline = (function () {
                             ed.editor.focus();
                         }
                     } else if(d.row !== undefined && d.row !== null) {
-                        eXide.app.locate("function", path == '' ? null: path, parseInt(d.row));
+                        var ed = eXide.app.getEditor();
+                        if (ed && ed.editor) {
+                            editorUtils.gotoLine(ed.editor, d.row + 1, d.column || 0, true);
+                        }
                     } else if(d.type == eXide.edit.Document.TYPE_FUNCTION) {
                         eXide.app.locate("function", path == '' ? null: path, d.name);
                     } else {

--- a/src/outline.js
+++ b/src/outline.js
@@ -60,12 +60,6 @@ eXide.edit.Outline = (function () {
         }
     };
 
-    function indentPrefix(level) {
-        var s = "";
-        for (var i = 0; i < level; i++) s += "\u00A0\u00A0";
-        return s;
-    }
-
     function docOrderSort(a, b) {
         var ra = a.row !== undefined ? a.row : 999999;
         var rb = b.row !== undefined ? b.row : 999999;
@@ -76,6 +70,86 @@ eXide.edit.Outline = (function () {
         var na = (a.name || "").toLowerCase();
         var nb = (b.name || "").toLowerCase();
         return na > nb ? 1 : na < nb ? -1 : 0;
+    }
+
+    /**
+     * Create the <a> element for an outline item with click handler.
+     */
+    function makeLink(d) {
+        var a = document.createElement("a");
+        if (d.signature) a.title = d.signature;
+        a.href = "#" + (d.source ? d.source : "");
+
+        var text = d.type == eXide.edit.Document.TYPE_VARIABLE ? "$" + d.name : d.name;
+        var nameSpan = document.createElement("span");
+        nameSpan.className = "outline-name";
+        nameSpan.textContent = text;
+        a.appendChild(nameSpan);
+
+        if (d.hint) {
+            var hintSpan = document.createElement("span");
+            hintSpan.className = "outline-hint";
+            hintSpan.textContent = " \u201C" + d.hint + "\u201D";
+            a.appendChild(hintSpan);
+        }
+
+        a.addEventListener("click", function(e) {
+            e.preventDefault();
+            var path = this.hash.substring(1);
+            if (d.from !== undefined && d.to !== undefined) {
+                var ed = eXide.app.getEditor();
+                if (ed && ed.editor) {
+                    ed.editor.dispatch({
+                        selection: { anchor: d.to, head: d.from }
+                    });
+                    ed.editor.dispatch({
+                        effects: CM6.EditorView.scrollIntoView(d.from, { y: "center" })
+                    });
+                    ed.editor.focus();
+                }
+            } else if(d.row !== undefined && d.row !== null) {
+                var ed = eXide.app.getEditor();
+                if (ed && ed.editor) {
+                    editorUtils.gotoLine(ed.editor, d.row + 1, d.column || 0, true);
+                }
+            } else if(d.type == eXide.edit.Document.TYPE_FUNCTION) {
+                eXide.app.locate("function", path == '' ? null: path, d.name);
+            } else {
+                eXide.app.locate("variable", path == '' ? null: path, d.name);
+            }
+        });
+
+        a.style.opacity = "0";
+        requestAnimationFrame(function() {
+            a.style.transition = "opacity 0.4s";
+            a.style.opacity = "1";
+        });
+
+        return a;
+    }
+
+    /**
+     * Create a <li> element with the appropriate CSS classes.
+     */
+    function makeLi(d) {
+        var li = document.createElement("li");
+        var cl = d.type == eXide.edit.Document.TYPE_FUNCTION ? "t_function" : "t_variable";
+        if (d.visibility === "private") cl += " private";
+        else if (d.visibility === "public") cl += " public";
+        if (d.outlineClass) cl += " " + d.outlineClass;
+        li.className = cl;
+        li.appendChild(makeLink(d));
+        return li;
+    }
+
+    /**
+     * Check whether any items have indent > 0 (i.e. the data is hierarchical).
+     */
+    function hasHierarchy(items) {
+        for (var i = 0; i < items.length; i++) {
+            if (items[i].indent > 0) return true;
+        }
+        return false;
     }
 
     Constr.prototype = {
@@ -135,8 +209,14 @@ eXide.edit.Outline = (function () {
 
             var helper = doc.getModeHelper();
             if (helper != null && this.__activated) {
-                helper.createOutline(doc, function() {
-                    self.$outlineUpdate(doc);
+                // Defer to let CM6 process language reconfiguration before
+                // walking the syntax tree (Lezer parses asynchronously)
+                requestAnimationFrame(function() {
+                    if (self.currentDoc !== doc) return;
+                    doc.functions = [];
+                    helper.createOutline(doc, function() {
+                        self.$outlineUpdate(doc);
+                    });
                 });
             }
         },
@@ -151,7 +231,7 @@ eXide.edit.Outline = (function () {
             var links = document.querySelectorAll("#outline li a");
             for (var i = 0; i < links.length; i++) {
                 var link = links[i];
-                link.style.display = regex.test(link.textContent) ? "" : "none";
+                link.parentNode.style.display = regex.test(link.textContent) ? "" : "none";
             }
         },
 
@@ -175,67 +255,55 @@ eXide.edit.Outline = (function () {
             var outline = document.getElementById("outline");
             outline.innerHTML = "";
 
+            // Use nested <ul> tree when in nested mode and data has hierarchy
+            if (nested && hasHierarchy(items)) {
+                this.$renderNested(outline, items);
+            } else {
+                this.$renderFlat(outline, items);
+            }
+        },
+
+        /**
+         * Render a flat list of <li> elements (for flat modes or non-hierarchical data).
+         */
+        $renderFlat: function(outline, items) {
             items.forEach(function(d) {
-                var li = document.createElement("li");
-                var cl = d.type == eXide.edit.Document.TYPE_FUNCTION ? "t_function" : "t_variable";
-                if (d.visibility === "private") cl += " private";
-                else if (d.visibility === "public") cl += " public";
-                if (d.outlineClass) cl += " " + d.outlineClass;
-                li.className = cl;
+                outline.appendChild(makeLi(d));
+            });
+        },
 
-                var a = document.createElement("a");
-                if (d.signature) a.title = d.signature;
-                a.href = "#" + (d.source ? d.source : "");
+        /**
+         * Render a nested <ul> tree based on indent levels.
+         * Each item with children gets a child <ul> inside its <li>.
+         */
+        $renderNested: function(outline, items) {
+            // Stack tracks the current <ul> at each depth level
+            var stack = [outline];
+            var currentDepth = 0;
 
-                var text = d.type == eXide.edit.Document.TYPE_VARIABLE ? "$" + d.name : d.name;
-                if (nested && d.indent) {
-                    text = indentPrefix(d.indent) + text;
-                }
-                var nameSpan = document.createElement("span");
-                nameSpan.className = "outline-name";
-                nameSpan.textContent = text;
-                a.appendChild(nameSpan);
+            items.forEach(function(d) {
+                var depth = d.indent || 0;
 
-                if (d.hint) {
-                    var hintSpan = document.createElement("span");
-                    hintSpan.className = "outline-hint";
-                    hintSpan.textContent = " \u201C" + d.hint + "\u201D";
-                    a.appendChild(hintSpan);
-                }
-
-                a.addEventListener("click", function(e) {
-                    e.preventDefault();
-                    var path = this.hash.substring(1);
-                    if (d.from !== undefined && d.to !== undefined) {
-                        var ed = eXide.app.getEditor();
-                        if (ed && ed.editor) {
-                            ed.editor.dispatch({
-                                selection: { anchor: d.from, head: d.to },
-                                scrollIntoView: true
-                            });
-                            ed.editor.focus();
-                        }
-                    } else if(d.row !== undefined && d.row !== null) {
-                        var ed = eXide.app.getEditor();
-                        if (ed && ed.editor) {
-                            editorUtils.gotoLine(ed.editor, d.row + 1, d.column || 0, true);
-                        }
-                    } else if(d.type == eXide.edit.Document.TYPE_FUNCTION) {
-                        eXide.app.locate("function", path == '' ? null: path, d.name);
+                // Go deeper: open new <ul> inside the last <li>
+                while (currentDepth < depth) {
+                    var ul = document.createElement("ul");
+                    var parentLi = stack[stack.length - 1].lastElementChild;
+                    if (parentLi) {
+                        parentLi.appendChild(ul);
                     } else {
-                        eXide.app.locate("variable", path == '' ? null: path, d.name);
+                        stack[stack.length - 1].appendChild(ul);
                     }
-                });
+                    stack.push(ul);
+                    currentDepth++;
+                }
 
-                a.style.opacity = "0";
-                li.appendChild(a);
-                outline.appendChild(li);
+                // Go shallower: pop back up the stack
+                while (currentDepth > depth && stack.length > 1) {
+                    stack.pop();
+                    currentDepth--;
+                }
 
-                // Fade in
-                requestAnimationFrame(function() {
-                    a.style.transition = "opacity 0.4s";
-                    a.style.opacity = "1";
-                });
+                stack[stack.length - 1].appendChild(makeLi(d));
             });
         }
     };

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -333,6 +333,10 @@ eXide.util.Preferences = (function () {
             btn.setAttribute('aria-pressed', this.preferences.splitPane ? 'true' : 'false');
             btn.textContent = this.preferences.splitPane ? '\u229E' : '\u229F';
         }
+        if (this.preferences.splitPane && this.editor && this.editor.outline) {
+            this.editor.outline.toggle(true);
+            this.editor.directory.toggle(true);
+        }
 
         // Panel visibility
         if (typeof eXide !== 'undefined' && eXide.app && eXide.app.setWestPanel) {

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -30,6 +30,7 @@ eXide.util.Preferences = (function () {
         font: "Default",
 		showInvisibles: false,
         autoPair: true,
+        autocompleteOnType: true,
 		showPrintMargin: true,
 		showHScroll: false,
         indent: -1,
@@ -123,6 +124,7 @@ eXide.util.Preferences = (function () {
 		form.querySelector('input[name="omit-xml-decl-on-download-package"]').checked = this.preferences.omitXMLDeclarationOnDownloadPackage;
 		form.querySelector('input[name="show-invisibles"]').checked = this.preferences.showInvisibles;
         form.querySelector('input[name="auto-pair"]').checked = this.preferences.autoPair;
+        form.querySelector('input[name="autocomplete-on-type"]').checked = this.preferences.autocompleteOnType !== false;
 		form.querySelector('input[name="print-margin"]').checked = this.preferences.showPrintMargin;
 		form.querySelector('input[name="emmet"]').checked = this.preferences.emmet;
 		form.querySelector('input[name="split-pane"]').checked = this.preferences.splitPane;
@@ -181,6 +183,7 @@ eXide.util.Preferences = (function () {
         this.preferences.font = form.querySelector('select[name="font"]').value;
 		this.preferences.showInvisibles = form.querySelector('input[name="show-invisibles"]').checked;
         this.preferences.autoPair = form.querySelector('input[name="auto-pair"]').checked;
+        this.preferences.autocompleteOnType = form.querySelector('input[name="autocomplete-on-type"]').checked;
 		this.preferences.showPrintMargin = form.querySelector('input[name="print-margin"]').checked;
 		this.preferences.emmet = form.querySelector('input[name="emmet"]').checked;
 		this.preferences.splitPane = form.querySelector('input[name="split-pane"]').checked;
@@ -311,6 +314,18 @@ eXide.util.Preferences = (function () {
                 var inv = this.preferences.showInvisibles;
                 effects.push(this.editor._showInvisiblesCompartment.reconfigure(
                     inv ? [CM6.highlightWhitespace(), CM6.highlightTrailingWhitespace()] : []
+                ));
+            }
+
+            // Autocomplete on typing
+            if (this.editor._autocompletionCompartment) {
+                effects.push(this.editor._autocompletionCompartment.reconfigure(
+                    CM6.autocompletion({
+                        override: [eXide.edit.CompletionSource.completionSource],
+                        activateOnTyping: this.preferences.autocompleteOnType !== false,
+                        maxRenderedOptions: 50,
+                        icons: true
+                    })
                 ));
             }
 

--- a/src/static-analysis.js
+++ b/src/static-analysis.js
@@ -15,6 +15,9 @@ var staticAnalysis = (function () {
     var WARNING = "warning";
     var LANG = "xquery";
 
+    // Registered module prefixes fetched from the server at startup
+    var registeredModulePrefixes = {};
+
     function warningMarker(pos, msg) {
         return { pos: pos, lang: LANG, type: WARNING, level: WARNING, message: msg };
     }
@@ -81,16 +84,22 @@ var staticAnalysis = (function () {
 
         // -- Namespace tracking --
         var namespaces = {
+            // W3C standard prefixes (always known)
             "local": "http://www.w3.org/2005/xquery-local-functions",
             "xs": "http://www.w3.org/2001/XMLSchema",
             "fn": "http://www.w3.org/2005/xpath-functions",
-            "jn": "http://www.jsoniq.org/functions",
-            "an": "http://www.zorba-xquery.com/annotations",
-            "db": "http://www.zorba-xquery.com/modules/store/static/collections/dml",
-            "idx": "http://www.zorba-xquery.com/modules/store/static/indexes/dml",
-            "zerr": "http://www.zorba-xquery.com/errors",
-            "err": "http://www.w3.org/2005/xqt-error"
+            "math": "http://www.w3.org/2005/xpath-functions/math",
+            "map": "http://www.w3.org/2005/xpath-functions/map",
+            "array": "http://www.w3.org/2005/xpath-functions/array",
+            "err": "http://www.w3.org/2005/xqt-error",
+            "output": "http://www.w3.org/2010/xslt-xquery-serialization"
         };
+        // Merge server-registered module prefixes (fetched at startup)
+        for (var p in registeredModulePrefixes) {
+            if (!namespaces[p]) {
+                namespaces[p] = registeredModulePrefixes[p];
+            }
+        }
         var declaredNS = {
             "jn": { ns: "http://www.jsoniq.org/functions", pos: { sl: 0, sc: 0, el: 0, ec: 0 }, type: "module", auto: true },
             "fn": { ns: "http://www.w3.org/2005/xpath-functions", pos: { sl: 0, sc: 0, el: 0, ec: 0 }, type: "module", auto: true }
@@ -694,7 +703,17 @@ var staticAnalysis = (function () {
         return { markers: markers };
     }
 
-    return { analyze: analyze };
+    return {
+        analyze: analyze,
+        setRegisteredModules: function (modules) {
+            registeredModulePrefixes = {};
+            for (var i = 0; i < modules.length; i++) {
+                if (modules[i].prefix && modules[i].uri) {
+                    registeredModulePrefixes[modules[i].prefix] = modules[i].uri;
+                }
+            }
+        }
+    };
 })();
 
 // Browser global (needed when bundled by esbuild)

--- a/src/xml-helper.js
+++ b/src/xml-helper.js
@@ -46,6 +46,7 @@ eXide.edit.XMLModeHelper = (function () {
         this.addCommand("rename", this.rename);
         this.addCommand("expandSelection", this.selectElement);
         this.addCommand("format", this.format);
+        this.addCommand("gotoSymbol", this.gotoSymbol);
     }
 
     eXide.util.oop.inherit(Constr, eXide.edit.ModeHelper);
@@ -76,6 +77,8 @@ eXide.edit.XMLModeHelper = (function () {
         var state = this.editor.state;
         var tree = CM6.ensureSyntaxTree(state, state.doc.length, 5000) || CM6.syntaxTree(state);
         var depth = 0;
+        var pathStack = [];    // track XPath steps with positional predicates
+        var siblingStack = [{}]; // stack of { tagName: count } maps per depth
         tree.iterate({
             enter: function(node) {
                 if (node.name === "Element" || node.name === "SelfClosingTag") {
@@ -110,13 +113,19 @@ eXide.edit.XMLModeHelper = (function () {
                     }
                     if (tagNameNode) {
                         var tagName = state.sliceDoc(tagNameNode.from, tagNameNode.to);
+                        // Track sibling position at current depth
+                        var siblings = siblingStack[siblingStack.length - 1];
+                        siblings[tagName] = (siblings[tagName] || 0) + 1;
+                        var step = tagName + "[" + siblings[tagName] + "]";
+                        pathStack.push(step);
+                        siblingStack.push({}); // new sibling scope for children
                         var hint = "";
                         var chosen = pickAttr(attrs);
                         if (chosen) {
                             hint = chosen.value;
                             if (hint.length > 30) hint = hint.substring(0, 30) + "…";
                         }
-                        var sigParts = attrs.map(function(a) { return a.name + '="' + a.value + '"'; });
+                        var xpath = "/" + pathStack.join("/");
                         var line = state.doc.lineAt(node.from);
                         doc.functions.push({
                             type: eXide.edit.Document.TYPE_FUNCTION,
@@ -125,12 +134,15 @@ eXide.edit.XMLModeHelper = (function () {
                             hint: hint,
                             outlineClass: "outline-element",
                             source: doc.getPath(),
-                            signature: "<" + tagName + (sigParts.length ? " " + sigParts.join(" ") : "") + ">",
+                            signature: xpath,
                             sort: String(line.number).padStart(6, "0"),
                             row: line.number - 1,
                             from: node.from,
                             to: node.to
                         });
+                    } else {
+                        pathStack.push("?");
+                        siblingStack.push({});
                     }
                     depth++;
                 } else if (node.name === "Comment") {
@@ -158,6 +170,8 @@ eXide.edit.XMLModeHelper = (function () {
             leave: function(node) {
                 if (node.name === "Element" || node.name === "SelfClosingTag") {
                     depth--;
+                    pathStack.pop();
+                    siblingStack.pop();
                 }
             }
         });

--- a/src/xml-helper.js
+++ b/src/xml-helper.js
@@ -73,8 +73,8 @@ eXide.edit.XMLModeHelper = (function () {
     }
 
     Constr.prototype.createOutline = function(doc, onComplete) {
-        var tree = CM6.syntaxTree(this.editor.state);
         var state = this.editor.state;
+        var tree = CM6.ensureSyntaxTree(state, state.doc.length, 5000) || CM6.syntaxTree(state);
         var depth = 0;
         tree.iterate({
             enter: function(node) {

--- a/src/xquery-completion.js
+++ b/src/xquery-completion.js
@@ -177,47 +177,25 @@ eXide.edit.CompletionSource = (function () {
     // -------------------------------------------------------------------
 
     function fetchFunctionCompletions(doc, helper, prefix, from, to) {
-        var params = new URLSearchParams({ prefix: prefix });
-
-        // Add module import params for imported function lookup
         var code = doc.getText();
-        var imports = helper.$parseImports(code);
-        if (imports) {
-            var basePath = "xmldb:exist://" + doc.getBasePath();
-            params.set("base", basePath);
-            for (var i = 0; i < imports.length; i++) {
-                var matches = helper.moduleRe.exec(imports[i]);
-                if (matches != null && matches.length === 4) {
-                    params.append("mprefix", matches[1]);
-                    params.append("uri", matches[2]);
-                    params.append("source", matches[3]);
-                }
-            }
-        }
+        var basePath = "xmldb:exist://" + doc.getBasePath();
 
-        return fetch("api/editor/completions?" + params.toString())
+        return fetch("api/query/completions", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ query: code, prefix: prefix, base: basePath })
+        })
             .then(function (response) { return response.json(); })
             .then(function (serverFuncs) {
                 var options = [];
-                var regex = new RegExp("^" + prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
 
-                // Local functions from AST
-                doc.functions.forEach(function (func) {
-                    if (func.type !== "variable" && func.name && func.name.match(regex)) {
-                        options.push(makeFunctionOption(func.signature || func.name,
-                            func.template || null, func.help || null, null, null,
-                            func.source || doc.getPath()));
-                    }
-                });
-
-                // Server functions (from /api/editor/completions)
+                // Server functions (from /api/query/completions via lsp:completions())
+                // Includes both built-in/imported functions AND user-defined local functions
                 if (serverFuncs) {
                     for (var i = 0; i < serverFuncs.length; i++) {
                         var f = serverFuncs[i];
                         options.push(makeFunctionOption(
-                            f.text, f.snippet, null,
-                            f.description, f.arguments,
-                            f.path));
+                            f.text, f.snippet, null, f.description, null, null));
                     }
                 }
 

--- a/src/xquery-completion.js
+++ b/src/xquery-completion.js
@@ -56,6 +56,16 @@ eXide.edit.CompletionSource = (function () {
         if (syntax === "xquery" && helper && helper.parseXQuery) {
             return xqueryCompletion(context, doc, helper);
         }
+        // Delegate to CM6's native completion sources for supported modes
+        if (syntax === "html" && CM6.htmlCompletionSource) {
+            return CM6.htmlCompletionSource(context);
+        }
+        if ((syntax === "css" || syntax === "less") && CM6.cssCompletionSource) {
+            return CM6.cssCompletionSource(context);
+        }
+        if ((syntax === "javascript" || syntax === "json") && CM6.localCompletionSource) {
+            return CM6.localCompletionSource(context);
+        }
         // Other modes: template snippets only
         return templateCompletion(context, doc, helper);
     }

--- a/src/xquery-helper.js
+++ b/src/xquery-helper.js
@@ -893,14 +893,52 @@ eXide.edit.XQueryModeHelper = (function () {
     
     Constr.prototype.createOutline = function(doc, onComplete) {
         var code = doc.getText();
-		this.$parseLocalFunctions(code, doc);
-//        if (onComplete)
-//            onComplete(doc);
-		var imports = this.$parseImports(code);
-		if (imports)
-			this.$resolveImports(doc, imports, onComplete);
-        else
-            onComplete(doc);
+        var basePath = "xmldb:exist://" + (doc.getBasePath ? doc.getBasePath() : "/db");
+        var imports = this.$parseImports(code);
+        var self = this;
+
+        doc.functions = [];
+
+        fetch("api/query/symbols", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ query: code, base: basePath })
+        })
+        .then(function(response) { return response.json(); })
+        .then(function(symbols) {
+            var localFuncs = [];
+            if (Array.isArray(symbols)) {
+                symbols.forEach(function(sym) {
+                    var isFunc = sym.kind === 12;
+                    // Strip arity suffix from function names ("local:foo#1" → "local:foo")
+                    var name = isFunc ? sym.name.replace(/#\d+$/, "") : sym.name.replace(/^\$/, "");
+                    localFuncs.push({
+                        type: isFunc ? eXide.edit.Document.TYPE_FUNCTION : eXide.edit.Document.TYPE_VARIABLE,
+                        name: name,
+                        signature: sym.detail || name,
+                        row: sym.line,
+                        column: sym.column
+                    });
+                });
+            }
+            // Assign atomically so concurrent calls don't accumulate duplicates
+            doc.functions = localFuncs;
+            if (imports && imports.length > 0) {
+                self.$resolveImports(doc, imports, onComplete);
+            } else {
+                onComplete(doc);
+            }
+        })
+        .catch(function(err) {
+            console.warn("[outline] symbols fetch failed, falling back:", err);
+            // Fall back to regex-based parsing
+            self.$parseLocalFunctions(code, doc);
+            if (imports && imports.length > 0) {
+                self.$resolveImports(doc, imports, onComplete);
+            } else {
+                onComplete(doc);
+            }
+        });
     }
     
     Constr.prototype.$sortFunctions = function(doc) {

--- a/src/xquery-helper.js
+++ b/src/xquery-helper.js
@@ -289,25 +289,51 @@ eXide.edit.XQueryModeHelper = (function () {
 
     Constr.prototype.gotoSymbol = function(doc) {
         var self = this;
-        var items = [];
-        for (var i = 0; i < doc.functions.length; i++) {
-            var item = {
-                label: doc.functions[i].signature ? doc.functions[i].signature : doc.functions[i].name,
-                name: doc.functions[i].name,
-                type: doc.functions[i].type
-            };
-            if (doc.functions[i].help) {
-                item.tooltip = doc.functions[i].help;
-            }
-            items.push(item);
-        }
-        if (items.length > 0) {
+        var code = this.editor.state.doc.toString();
+        var basePath = "xmldb:exist://" + (doc.getBasePath ? doc.getBasePath() : "/db");
+
+        fetch("api/query/symbols", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ query: code, base: basePath })
+        })
+        .then(function (response) { return response.json(); })
+        .then(function (symbols) {
+            if (!symbols || !symbols.length) return;
+            var items = symbols.map(function (sym) {
+                return {
+                    // detail has the full signature for functions; name for variables
+                    label: sym.detail || sym.name,
+                    name: sym.name,
+                    line: sym.line,
+                    column: sym.column
+                };
+            });
             eXide.util.QuickPicker.show(items, function (selected) {
                 if (selected) {
-                    self.parent.outline.gotoDefinition(doc, selected.name);
+                    // lsp:symbols() returns 0-based line; gotoLine expects 1-based
+                    editorUtils.gotoLine(self.editor, selected.line + 1, selected.column, true);
                 }
             }, { placeholder: "Go to symbol\u2026", parentEditor: self.editor });
-        }
+        })
+        .catch(function () {
+            // Fall back to AST-based symbol list
+            var items = doc.functions.map(function (f) {
+                return {
+                    label: f.signature || f.name,
+                    name: f.name,
+                    line: f.row,
+                    column: 0
+                };
+            });
+            if (items.length > 0) {
+                eXide.util.QuickPicker.show(items, function (selected) {
+                    if (selected) {
+                        editorUtils.gotoLine(self.editor, selected.line + 1, 0, true);
+                    }
+                }, { placeholder: "Go to symbol\u2026", parentEditor: self.editor });
+            }
+        });
     };
 
 	Constr.prototype.getFunctionAtCursor = function (doc, lead) {
@@ -450,17 +476,48 @@ eXide.edit.XQueryModeHelper = (function () {
     };
     
 	Constr.prototype.gotoDefinition = function (doc) {
-        this.parseXQuery(doc);
-		var lead = editorUtils.offsetToRowCol(this.editor.state, this.editor.state.selection.main.head);
-		var funcName = this.getFunctionAtCursor(doc, lead);
-		if (funcName) {
-			this.parent.outline.gotoDefinition(doc, funcName);
-		} else {
-		    var varName = this.getVariableAtCursor(doc, lead);
-		    if (varName) {
-		        this.parent.outline.gotoDefinition(doc, varName);
-		    }
-		}
+        var self = this;
+        var lead = editorUtils.offsetToRowCol(this.editor.state, this.editor.state.selection.main.head);
+        var code = this.editor.state.doc.toString();
+        var basePath = "xmldb:exist://" + (doc.getBasePath ? doc.getBasePath() : "/db");
+
+        fetch("api/query/definition", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                query: code,
+                line: lead.row,      // 0-based
+                column: lead.column, // 0-based
+                base: basePath
+            })
+        })
+        .then(function (response) { return response.json(); })
+        .then(function (data) {
+            if (data && data.line !== undefined) {
+                // Server returns 0-based line; gotoLine expects 1-based
+                editorUtils.gotoLine(self.editor, data.line + 1, data.column, true);
+            } else {
+                // Fall back to AST-based local definition lookup
+                self.parseXQuery(doc);
+                var funcName = self.getFunctionAtCursor(doc, lead);
+                if (funcName) {
+                    self.parent.outline.gotoDefinition(doc, funcName);
+                } else {
+                    var varName = self.getVariableAtCursor(doc, lead);
+                    if (varName) {
+                        self.parent.outline.gotoDefinition(doc, varName);
+                    }
+                }
+            }
+        })
+        .catch(function () {
+            // Network error: fall back to AST lookup
+            self.parseXQuery(doc);
+            var funcName = self.getFunctionAtCursor(doc, lead);
+            if (funcName) {
+                self.parent.outline.gotoDefinition(doc, funcName);
+            }
+        });
 	}
 	
 	Constr.prototype.locate = function(doc, type, name) {

--- a/src/xquery-helper.js
+++ b/src/xquery-helper.js
@@ -212,7 +212,7 @@ eXide.edit.XQueryModeHelper = (function () {
 	};
 	
     Constr.prototype.parseXQuery = function(doc) {
-        if (doc.ast && doc.lastValidation >= doc.getLastChanged()) {
+        if (doc.ast && doc.lastParsed >= doc.getLastChanged()) {
             return;
         }
         var value = doc.getText();
@@ -231,7 +231,7 @@ eXide.edit.XQueryModeHelper = (function () {
         // If 4.0 parser is still loading, re-parse when it arrives
         if (selection.pending) {
             parserRegistry.loadParser40().then(function () {
-                doc.lastValidation = 0; // force re-parse
+                doc.lastParsed = 0; // force re-parse
                 self.parseXQuery(doc);
             }).catch(function (err) {
                 console.warn("Failed to load XQuery 4.0 parser:", err.message);
@@ -244,7 +244,7 @@ eXide.edit.XQueryModeHelper = (function () {
         try {
             doc.ast = result.ast;
             doc.ast.markers = [];
-            doc.lastValidation = new Date().getTime();
+            doc.lastParsed = new Date().getTime();
 
             try {
                 var analysisResult = staticAnalysis.analyze(result.ast);

--- a/src/xquery-helper.js
+++ b/src/xquery-helper.js
@@ -494,8 +494,20 @@ eXide.edit.XQueryModeHelper = (function () {
         .then(function (response) { return response.json(); })
         .then(function (data) {
             if (data && data.line !== undefined) {
-                // Server returns 0-based line; gotoLine expects 1-based
-                editorUtils.gotoLine(self.editor, data.line + 1, data.column, true);
+                if (data.uri) {
+                    // Cross-module definition: open the target module
+                    var targetPath = data.uri;
+                    var resource = {
+                        path: targetPath,
+                        name: targetPath.replace(/^.*\//, ""),
+                        writable: true,
+                        line: data.line + 1  // gotoLine expects 1-based
+                    };
+                    self.parent.$doOpenDocument(resource);
+                } else {
+                    // Same-file definition: jump to the line
+                    editorUtils.gotoLine(self.editor, data.line + 1, data.column, true);
+                }
             } else {
                 // Fall back to AST-based local definition lookup
                 self.parseXQuery(doc);

--- a/tools/bundle-cm6.js
+++ b/tools/bundle-cm6.js
@@ -14,7 +14,7 @@ import {EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLin
         highlightSpecialChars, highlightWhitespace, highlightTrailingWhitespace,
         scrollPastEnd,
         Decoration, ViewPlugin, WidgetType, gutter, GutterMarker,
-        showTooltip, tooltips} from "@codemirror/view";
+        showTooltip, tooltips, hoverTooltip} from "@codemirror/view";
 import {syntaxHighlighting, HighlightStyle, indentOnInput, foldGutter, foldKeymap,
         bracketMatching, defaultHighlightStyle, indentUnit, StreamLanguage,
         syntaxTree, foldNodeProp, foldInside, Language, LRLanguage,
@@ -71,6 +71,7 @@ globalThis.CM6 = {
     GutterMarker,
     showTooltip,
     tooltips,
+    hoverTooltip,
 
     // @codemirror/language
     syntaxHighlighting,

--- a/tools/bundle-cm6.js
+++ b/tools/bundle-cm6.js
@@ -17,7 +17,7 @@ import {EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLin
         showTooltip, tooltips, hoverTooltip} from "@codemirror/view";
 import {syntaxHighlighting, HighlightStyle, indentOnInput, foldGutter, foldKeymap,
         bracketMatching, defaultHighlightStyle, indentUnit, StreamLanguage,
-        syntaxTree, foldNodeProp, foldInside, Language, LRLanguage,
+        syntaxTree, ensureSyntaxTree, foldNodeProp, foldInside, Language, LRLanguage,
         LanguageSupport, LanguageDescription} from "@codemirror/language";
 import {defaultKeymap, history, historyKeymap, indentWithTab, undo, redo, toggleComment} from "@codemirror/commands";
 import {searchKeymap, openSearchPanel, closeSearchPanel, search, findNext, findPrevious,
@@ -30,11 +30,11 @@ import {lintKeymap, setDiagnostics, forEachDiagnostic, linter, lintGutter,
         openLintPanel, closeLintPanel} from "@codemirror/lint";
 import {StreamLanguage as LegacyStreamLanguage} from "@codemirror/language";
 import * as legacyModes from "@codemirror/legacy-modes/mode/xquery";
-import {javascript} from "@codemirror/lang-javascript";
-import {css} from "@codemirror/lang-css";
-import {html} from "@codemirror/lang-html";
+import {javascript, localCompletionSource, snippets as jsSnippets} from "@codemirror/lang-javascript";
+import {css, cssCompletionSource} from "@codemirror/lang-css";
+import {html, htmlCompletionSource, autoCloseTags as htmlAutoCloseTags} from "@codemirror/lang-html";
 import {xml} from "@codemirror/lang-xml";
-import {json} from "@codemirror/lang-json";
+import {json, jsonParseLinter} from "@codemirror/lang-json";
 import {markdown} from "@codemirror/lang-markdown";
 import {oneDark, oneDarkTheme, oneDarkHighlightStyle} from "@codemirror/theme-one-dark";
 import {languages} from "@codemirror/language-data";
@@ -84,6 +84,7 @@ globalThis.CM6 = {
     indentUnit,
     StreamLanguage,
     syntaxTree,
+    ensureSyntaxTree,
     foldNodeProp,
     foldInside,
     Language,
@@ -149,6 +150,13 @@ globalThis.CM6 = {
     json,
     markdown,
     languages,
+
+    // Language-specific completion sources & linting
+    htmlCompletionSource,
+    cssCompletionSource,
+    localCompletionSource: localCompletionSource,
+    jsSnippets,
+    jsonParseLinter,
 
     // Themes
     oneDark,

--- a/tools/bundle-cm6.js
+++ b/tools/bundle-cm6.js
@@ -22,7 +22,8 @@ import {syntaxHighlighting, HighlightStyle, indentOnInput, foldGutter, foldKeyma
 import {defaultKeymap, history, historyKeymap, indentWithTab, undo, redo, toggleComment} from "@codemirror/commands";
 import {searchKeymap, openSearchPanel, closeSearchPanel, search, findNext, findPrevious,
         replaceNext, replaceAll, SearchQuery, setSearchQuery, getSearchQuery,
-        SearchCursor} from "@codemirror/search";
+        SearchCursor, highlightSelectionMatches, selectNextOccurrence} from "@codemirror/search";
+import {placeholder} from "@codemirror/view";
 import {autocompletion, completionKeymap, CompletionContext, startCompletion,
         acceptCompletion, closeCompletion, snippet, snippetCompletion,
         closeBrackets, closeBracketsKeymap} from "@codemirror/autocomplete";
@@ -114,6 +115,9 @@ globalThis.CM6 = {
     setSearchQuery,
     getSearchQuery,
     SearchCursor,
+    highlightSelectionMatches,
+    selectNextOccurrence,
+    placeholder,
 
     // @codemirror/autocomplete
     autocompletion,


### PR DESCRIPTION
## Summary

Wires eXist-db's `lsp:*` XQuery module into the eXide frontend, adding five LSP-backed features. Depends on the `feature/lsp-module` branch in `eXist-db/exist`.

- **Hover tooltips** — CM6 `hoverTooltip` extension calls `lsp:hover()` and renders function signatures and documentation when hovering over XQuery symbols
- **Go-to-definition** — replaces AST-based lookup with `lsp:definition()` for accurate jump-to-source including imported modules
- **Function completions** — replaces the old GET endpoint with `lsp:completions()` which includes user-defined local functions; prefix-filtered server-side; CM6 snippet templates generated from parameter names
- **Navigate → Symbol** — `lsp:symbols()` powers the Quick Picker symbol list (Ctrl+Shift+O)
- **Outline panel** — populated via `lsp:symbols()` with atomic assignment to prevent race-condition duplicates; click handler fixed to use `editorUtils.gotoLine()` with correct row/column; outline now activates correctly when split-pane mode is restored from localStorage

## What Changed

- `modules/api/query.xqm` — four new endpoints: `POST /api/query/hover`, `POST /api/query/definition`, `POST /api/query/completions`, `POST /api/query/symbols`
- `modules/api.json` — OpenAPI routes for the four new endpoints
- `src/lsp-hover.js` *(new)* — CM6 `hoverTooltip` extension; fetches hover data, renders signature + description
- `resources/css/lsp-hover.css` *(new)* — tooltip styles with dark-mode support
- `src/editor.js` — registers `LspHover.extension()` in the CM6 extension list
- `tools/bundle-cm6.js` — exports `hoverTooltip` from the CM6 bundle
- `scripts/bundle.js` — includes `lsp-hover.js` in the esbuild entry
- `index.html.tmpl` — loads `lsp-hover.css`
- `src/xquery-helper.js` — `gotoDefinition` uses `lsp:definition()`; `gotoSymbol` uses `lsp:symbols()`; `createOutline` uses `lsp:symbols()` with regex fallback on failure
- `src/xquery-completion.js` — `fetchFunctionCompletions` calls `POST /api/query/completions`
- `src/outline.js` — click handler uses `editorUtils.gotoLine()` with LSP row/column; removed redundant `doc.functions = []` reset
- `src/preferences.js` — activates outline in `applyPreferences()` when split-pane is restored from localStorage

## Prerequisites

eXist-db must have the `feature/lsp-module` branch deployed, which provides `lsp:hover`, `lsp:definition`, `lsp:completions`, `lsp:symbols`, and `lsp:diagnostics`.

## Test Plan

- [ ] Hover over a function name → tooltip shows signature and documentation
- [ ] Go to Definition on a local function → cursor jumps to declaration
- [ ] Ctrl+Space mid-function-name → completions include built-ins and user-defined local functions
- [ ] Navigate → Symbol (Ctrl+Shift+O) → all declared functions and variables listed
- [ ] Outline panel (tabbed mode) → functions appear after clicking the outline tab
- [ ] Outline panel (split-pane mode) → functions appear on startup without clicking the tab
- [ ] Clicking an outline item → cursor jumps to correct line and column
- [ ] No duplicate entries in outline after document save/validate
- [ ] All features degrade gracefully when LSP module is not available

🤖 Generated with [Claude Code](https://claude.com/claude-code)